### PR TITLE
Fix surfplots import error

### DIFF
--- a/melodies_monet/plots/__init__.py
+++ b/melodies_monet/plots/__init__.py
@@ -6,8 +6,6 @@ from pathlib import Path
 
 from monet import savefig as monet_savefig
 
-from . import surfplots
-
 __all__ = (
     "savefig",
     "surfplots",
@@ -16,3 +14,5 @@ __all__ = (
 LOGO_PATH = Path(__file__).parent / "../data/MM_logo.png"
 
 savefig = partial(monet_savefig, logo=LOGO_PATH, loc=2, decorate=True, bbox_inches="tight", dpi=200)
+
+from . import surfplots


### PR DESCRIPTION
I introduced a circular import when resolving the merge conflict in `plots/__init__.py` for #53 