### PR TITLE
Add more clone note to main install doc

### DIFF
--- a/docs/tutorial/installation.rst
+++ b/docs/tutorial/installation.rst
@@ -29,6 +29,11 @@ follow these machine specific instructions instead.
 - :ref:`NCAR Cheyenne <appendix/machine-specific-install:NCAR HPC Cheyenne/Casper>`
 - :ref:`NOAA Hera <appendix/machine-specific-install:NOAA HPC Hera>`
 
+.. important::
+   The instructions below are for cloning a repository using SSH.
+   If you prefer, you can also clone the monet, monetio, and
+   MELODIES-MONET repositories using HTTPS [#clone]_.
+
 To install MELODIES MONET on your laptop or on HPC machines in general follow 
 these instructions: 
  


### PR DESCRIPTION
Add a more-obvious note about the cloning to the main installation page of the docs.

Based on discussion in #76