### PR TITLE
Dev note on install page

### DIFF
--- a/docs/background/supported_datasets.rst
+++ b/docs/background/supported_datasets.rst
@@ -38,7 +38,8 @@ Surface
      (in MONET, coming soon to MELODIES MONET)
    * `CEMS <https://www.epa.gov/emc/emc-continuous-emission-monitoring-systems/>`_ 
      (in MONET, coming soon to MELODIES MONET)
-   * `ISD <https://www.ncdc.noaa.gov/isd/>`_ (in MONET, coming soon to MELODIES MONET)
+   * `ISD <https://www.ncei.noaa.gov/products/land-based-station/integrated-surface-database>`_
+     (in MONET, coming soon to MELODIES MONET)
    
 See the `Expand Surface Observations <https://github.com/NOAA-CSL/MELODIES-MONET/projects/7>`_ 
 project on GitHub to learn about current and future development.

--- a/docs/tutorial/installation.rst
+++ b/docs/tutorial/installation.rst
@@ -40,6 +40,11 @@ Now, install the stable branch of MELODIES MONET to the environment::
     $ pip install --no-deps https://github.com/NOAA-CSL/MELODIES-MONET/archive/main.zip
 
 
+.. note::
+   If you are interested in modifying what MELODIES MONET can do
+   take a look at the :doc:`/develop/developers_guide`.
+
+
 .. [#yaml] Examples of `conda <https://conda.io>`__
    `environment.yml files <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#creating-an-environment-from-an-environment-yml-file>`__
    that include a record

--- a/docs/tutorial/installation.rst
+++ b/docs/tutorial/installation.rst
@@ -41,7 +41,7 @@ Now, install the stable branch of MELODIES MONET to the environment::
 
 
 .. note::
-   If you are interested in modifying what MELODIES MONET can do
+   If you are interested in modifying what MELODIES MONET can do,
    take a look at the :doc:`/develop/developers_guide`.
 
 


### PR DESCRIPTION
This adds a link to the developer's guide doc to the main install docs page.
@bbakernoaa suggested doing this at the last meeting.