### PR TITLE
Drop unused variables in observation dataset to reduce memory usage of corresponding dataframe

### DIFF
--- a/melodies_monet/driver.py
+++ b/melodies_monet/driver.py
@@ -238,8 +238,6 @@ class observation:
         None
         """
         self.obj = self.obj.to_dataframe().reset_index().drop(['x', 'y'], axis=1)
-        print(self.obj.info())
-        print(self.obj.memory_usage())
 
 
 class model:

--- a/melodies_monet/driver.py
+++ b/melodies_monet/driver.py
@@ -183,10 +183,15 @@ class observation:
 
     def drop_unused(self):
 
+        # append timestamps and other site info to list of mapped variables
+        used_vars = list(self.variable_dict.keys()) \
+            + ['time_local', 'utcoffset', 'units',
+               'site', 'state_name', 'epa_region']
+
         # drop unused variables
         print()
         for var in self.obj.keys():
-            if var not in self.variable_dict:
+            if var not in used_vars:
                 print('observation.drop_unused:dropping:' + var)
                 self.obj = self.obj.drop_vars(var)
 
@@ -232,10 +237,7 @@ class observation:
         -------
         None
         """
-        try:
-            self.obj = self.obj.to_dataframe().reset_index().drop(['x', 'y'], axis=1)
-        except:
-            self.obj = self.obj.to_dataframe().reset_index()
+        self.obj = self.obj.to_dataframe().reset_index().drop(['x', 'y'], axis=1)
         print(self.obj.info())
         print(self.obj.memory_usage())
 

--- a/melodies_monet/driver.py
+++ b/melodies_monet/driver.py
@@ -176,9 +176,11 @@ class observation:
     def drop_unused(self):
 
         # append timestamps and other site info to list of mapped variables
+        # also any vars that end in '_region'
         used_vars = list(self.variable_dict.keys()) \
-            + ['time_local', 'utcoffset', 'units',
-               'site', 'state_name', 'epa_region']
+            + ['time', 'time_local', 'utcoffset', 'units',
+               'site', 'siteid', 'state_name', 'epa_region',
+               'cmsa_name', 'msa_code', 'msa_name']
 
         # drop unused variables
         print()


### PR DESCRIPTION
I have tested this within the unit tests in the develop_testsuite branch with test_obs.py,
which demonstrates reduced memory usage after observertion.obs_to_df.
The YAML parameter drop_unused_vars can be added to an observation dataset.
Need to test on larger examples.

```yaml
obs:
    test_obs:
        filename: test_obs.nc
        obs_type: pt_sfc
        drop_unused_vars: True
        variables:
            A_obs:
                units: 'Units of A'
                unit_scale: 1
                unit_scale_method: '*'
            B_obs:
                units: 'Units of B' 
                unit_scale: 1
                unit_scale_method: '*'
```