### PR TITLE
Upgrade Python to 3.9 in CI env

### DIFF
--- a/docs/environment-docs.yml
+++ b/docs/environment-docs.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - python=3.8
+  - python=3.9
   #
   # melodies_monet deps
   - monet


### PR DESCRIPTION
Makes sense to use 3.9 here since that is what we are recommending to users.