### PR TITLE
Add basic pairing for aircraft observations

### DIFF
--- a/examples/yaml/control_wrfchem_aircraft.yaml
+++ b/examples/yaml/control_wrfchem_aircraft.yaml
@@ -8,7 +8,6 @@ analysis:
   end_time: '2019-09-06-00:00:00' #UTC
   output_dir: /wrk/charkins/melodies_monet/aircraft/analysis #Opt if not specified plots stored in code directory.
   debug: True
-  resample: '600S' #6 min so works on Hera as a test. Can comment this if submitting a job.
 model:
   wrfchem_v4.2: # model label
     # files: /wrk/d2/rschwantes/wrf/firex_mech/qzhu/run_CONUS_fv19_BEIS_1.0xISO_RACM_v4.2.2_racm_berk_vcp_noI_phot_soa/0905/*
@@ -41,11 +40,14 @@ obs:
   firexaq: # obs label
     filename: '/wrk/d2/rschwantes/obs/firex-aq/R1/10s_merge/firexaq-mrg10-dc8_merge_20190905_R1.ict'
     obs_type: aircraft
+    resample: '600S' #10 min so works on Hera as a test. Can comment this if submitting a job. 
     variables: #Opt 
       'O3_CL_RYERSON':
         unit_scale: 1 #Opt Scaling factor 
         unit_scale_method: '*' #Opt Multiply = '*' , Add = '+', subtract = '-', divide = '/'
         nan_value: -777777 # Opt Set this value to NaN
+        LLOD_value: -888888 # Opt Set this value to LLOD_setvalue
+        LLOD_setvalue: 0.0 # Opt Set LLOD_value=LLOD_setvalue, applied AFTER unit_scale and obs_unit
         ylabel_plot: 'Ozone (ppbv)'
         vmin_plot: 15.0 #Opt Min for y-axis during plotting. To apply to a plot, change restrict_yaxis = True.
         vmax_plot: 55.0 #Opt Max for y-axis during plotting. To apply to a plot, change restrict_yaxis = True.
@@ -53,6 +55,8 @@ obs:
         # nlevels_plot: 21 #Opt number of levels used in colorbar for contourf plot.
       'NO_CL_RYERSON':
         nan_value: -777777 # Set this value to NaN
+        LLOD_value: -888888 # Opt Set this value to LLOD_setvalue
+        LLOD_setvalue: 0.0 # Opt Set LLOD_value=LLOD_setvalue, applied AFTER unit_scale and obs_unit
         ylabel_plot: 'NO (ppbv)' #Optional to set ylabel so can include units and/or instr etc.
         vmin_plot: 0.0 #Opt Min for y-axis during plotting. To apply to a plot, change restrict_yaxis = True.
         vmax_plot: 20.0 #Opt Max for y-axis during plotting. To apply to a plot, change restrict_yaxis = True.
@@ -60,6 +64,8 @@ obs:
         nlevels_plot: 21 #Opt number of levels used in colorbar for contourf plot.
       'NO2_CL_RYERSON':
         nan_value: -777777 # Set this value to NaN
+        LLOD_value: -888888 # Opt Set this value to LLOD_setvalue
+        LLOD_setvalue: 0.0 # Opt Set LLOD_value=LLOD_setvalue, applied AFTER unit_scale and obs_unit
         ylabel_plot: 'NO2 (ppbv)' #Optional to set ylabel so can include units and/or instr etc.
         vmin_plot: 0.0 #Opt Min for y-axis during plotting. To apply to a plot, change restrict_yaxis = True.
         vmax_plot: 20.0 #Opt Max for y-axis during plotting. To apply to a plot, change restrict_yaxis = True.

--- a/examples/yaml/control_wrfchem_aircraft.yaml
+++ b/examples/yaml/control_wrfchem_aircraft.yaml
@@ -1,0 +1,141 @@
+# General Description:  
+# Any key that is specific for a plot type will begin with ts for timeseries, ty for taylor
+# Opt: Specifying the variable or variable group is optional
+# For now all plots except time series average over the analysis window. 
+# Seting axis values - If set_axis = True in data_proc section of each plot_grp the yaxis for the plot will be set based on the values specified in the obs section for each variable. If set_axis is set to False, then defaults will be used. 'vmin_plot' and 'vmax_plot' are needed for 'timeseries', 'spatial_overlay', and 'boxplot'. 'vdiff_plot' is needed for 'spatial_bias' plots and'ty_scale' is needed for 'taylor' plots. 'nlevels' or the number of levels used in the contour plot can also optionally be provided for spatial_overlay plot. If set_axis = True and the proper limits are not provided in the obs section, a warning will print, and the plot will be created using the default limits.
+analysis:
+  start_time: '2019-09-05-12:00:00' #UTC
+  end_time: '2019-09-06-00:00:00' #UTC
+  output_dir: /wrk/charkins/melodies_monet/aircraft/analysis #Opt if not specified plots stored in code directory.
+  debug: True
+  resample: '600S' #6 min so works on Hera as a test. Can comment this if submitting a job.
+model:
+  wrfchem_v4.2: # model label
+    # files: /wrk/d2/rschwantes/wrf/firex_mech/qzhu/run_CONUS_fv19_BEIS_1.0xISO_RACM_v4.2.2_racm_berk_vcp_noI_phot_soa/0905/*
+    files: /wrk/d2/rschwantes/wrf/firex_mech/qzhu/run_CONUS_fv19_BEIS_1.0xISO_RACM_v4.2.2_racm_berk_vcp_noI_phot_soa/0905/*
+    mod_type: 'wrfchem'
+    mod_kwargs: 
+      mech: 'racm_esrl_vcp'
+    radius_of_influence: 12000 #meters
+    mapping: #model species name : obs species name
+      firexaq:
+        no2: NO2_CL_RYERSON
+        'no': 'NO_CL_RYERSON'
+        #PM2_5_DRY: "PM2.5"
+        o3: "O3_CL_RYERSON"
+    variables:
+        'pres_pa_mid':
+            rename: pressure_model # name to convert this variable to, use 'pressure_model' for aircraft obs
+            unit_scale: 1 #Opt Scaling factor 
+            unit_scale_method: '*' #Opt Multiply = '*' , Add = '+', subtract = '-', divide = '/'
+        'temperature_k':
+            rename: temp_model # name to convert this variable to
+            unit_scale: 1 #Opt Scaling factor 
+            unit_scale_method: '*' #Opt Multiply = '*' , Add = '+', subtract = '-', divide = '/'
+    projection: None
+    plot_kwargs: #Opt
+      color: 'dodgerblue'
+      marker: '^'
+      linestyle: ':' 
+obs:
+  firexaq: # obs label
+    filename: '/wrk/d2/rschwantes/obs/firex-aq/R1/10s_merge/firexaq-mrg10-dc8_merge_20190905_R1.ict'
+    obs_type: aircraft
+    variables: #Opt 
+      'O3_CL_RYERSON':
+        unit_scale: 1 #Opt Scaling factor 
+        unit_scale_method: '*' #Opt Multiply = '*' , Add = '+', subtract = '-', divide = '/'
+        nan_value: -777777 # Opt Set this value to NaN
+        ylabel_plot: 'Ozone (ppbv)'
+        vmin_plot: 15.0 #Opt Min for y-axis during plotting. To apply to a plot, change restrict_yaxis = True.
+        vmax_plot: 55.0 #Opt Max for y-axis during plotting. To apply to a plot, change restrict_yaxis = True.
+        vdiff_plot: 20.0 #Opt +/- range to use in bias plots. To apply to a plot, change restrict_yaxis = True.
+        # nlevels_plot: 21 #Opt number of levels used in colorbar for contourf plot.
+      'NO_CL_RYERSON':
+        nan_value: -777777 # Set this value to NaN
+        ylabel_plot: 'NO (ppbv)' #Optional to set ylabel so can include units and/or instr etc.
+        vmin_plot: 0.0 #Opt Min for y-axis during plotting. To apply to a plot, change restrict_yaxis = True.
+        vmax_plot: 20.0 #Opt Max for y-axis during plotting. To apply to a plot, change restrict_yaxis = True.
+        vdiff_plot: 15.0 #Opt +/- range to use in bias plots. To apply to a plot, change restrict_yaxis = True.
+        nlevels_plot: 21 #Opt number of levels used in colorbar for contourf plot.
+      'NO2_CL_RYERSON':
+        nan_value: -777777 # Set this value to NaN
+        ylabel_plot: 'NO2 (ppbv)' #Optional to set ylabel so can include units and/or instr etc.
+        vmin_plot: 0.0 #Opt Min for y-axis during plotting. To apply to a plot, change restrict_yaxis = True.
+        vmax_plot: 20.0 #Opt Max for y-axis during plotting. To apply to a plot, change restrict_yaxis = True.
+        vdiff_plot: 15.0 #Opt +/- range to use in bias plots. To apply to a plot, change restrict_yaxis = True.
+        nlevels_plot: 21 #Opt number of levels used in colorbar for contourf plot.
+      'Latitude_YANG':
+            rename: latitude # name to convert this variable to
+            unit_scale: 1 #Opt Scaling factor 
+            unit_scale_method: '*' #Opt Multiply = '*' , Add = '+', subtract = '-', divide = '/'
+      'Longitude_YANG':
+            rename: longitude # name to convert this variable to
+            unit_scale: 1 #Opt Scaling factor 
+            unit_scale_method: '*' #Opt Multiply = '*' , Add = '+', subtract = '-', divide = '/'
+      'P_BUI':
+            rename: pressure_obs # name to convert this variable to
+            unit_scale: 100 #Opt Scaling factor 
+            unit_scale_method: '*' #Opt Multiply = '*' , Add = '+', subtract = '-', divide = '/'
+plots:
+  plot_grp1:
+    type: 'timeseries' # plot type
+    fig_kwargs: #Opt to define figure options
+      figsize: [12,6] # figure size if multiple plots
+    default_plot_kwargs: # Opt to define defaults for all plots. Model kwargs overwrite these.
+      linewidth: 2.0
+      markersize: 10.
+    text_kwargs: #Opt
+      fontsize: 18.
+    domain_type: ['all'] #List of domain types: 'all' or any domain in obs file. (e.g., airnow: epa_region, state_name, siteid, etc.) 
+    domain_name: ['CONUS'] #List of domain names. If domain_type = all domain_name is used in plot title.
+    data: ['firexaq_wrfchem_v4.2'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
+    data_proc:
+      rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
+      ts_select_time: 'time' #Time used for avg and plotting: Options: 'time' for UTC or 'time_local'
+      ts_avg_window: 'H' # Options: None for no averaging or list pandas resample rule (e.g., 'H', 'D')
+      set_axis: False #If select True, add vmin_plot and vmax_plot for each variable in obs.
+  plot_grp2:
+    type: 'taylor' # plot type
+    fig_kwargs: #Opt to define figure options
+      figsize: [8,8] # figure size if multiple plots
+    default_plot_kwargs: # Opt to define defaults for all plots. Model kwargs overwrite these.
+      linewidth: 2.0
+      markersize: 10.
+    text_kwargs: #Opt
+      fontsize: 16.
+    domain_type: ['all'] #List of domain types: 'all' or any domain in obs file. (e.g., airnow: epa_region, state_name, siteid, etc.) 
+    domain_name: ['CONUS'] #List of domain names. If domain_type = all domain_name is used in plot title.
+    data: ['firexaq_wrfchem_v4.2'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
+    data_proc:
+      rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
+      set_axis: True #If select True, add ty_scale for each variable in obs.
+  plot_grp3:
+    type: 'boxplot' # plot type
+    fig_kwargs: #Opt to define figure options
+      figsize: [8, 6] # figure size 
+    text_kwargs: #Opt
+      fontsize: 20.
+    domain_type: ['all'] #List of domain types: 'all' or any domain in obs file. (e.g., airnow: epa_region, state_name, siteid, etc.) 
+    domain_name: ['CONUS'] #List of domain names. If domain_type = all domain_name is used in plot title.
+    data: ['firexaq_wrfchem_v4.2'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
+    data_proc:
+      rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
+      set_axis: False #If select True, add vmin_plot and vmax_plot for each variable in obs.
+stats:
+  #Stats require positive numbers, so if you want to calculate temperature use Kelvin!
+  #Wind direction has special calculations for AirNow if obs name is 'WD'
+  stat_list: ['MB', 'MdnB','R2', 'RMSE'] #List stats to calculate. Dictionary of definitions included in plots/proc_stats.py Only stats listed below are currently working.
+  #Full calc list ['STDO', 'STDP', 'MdnNB','MdnNE','NMdnGE', 'NO','NOP','NP','MO','MP', 'MdnO', 'MdnP', 'RM', 'RMdn', 'MB', 'MdnB', 'NMB', 'NMdnB', 'FB', 'ME','MdnE','NME', 'NMdnE', 'FE', 'R2', 'RMSE','d1','E1', 'IOA', 'AC']
+  round_output: 2 #Opt, defaults to rounding to 3rd decimal place.
+  output_table: False #Always outputs a .txt file. Optional to also output as a table.
+  output_table_kwargs: #Opt 
+    figsize: [7, 3] # figure size 
+    fontsize: 12.
+    xscale: 1.4
+    yscale: 1.4
+    edges: 'horizontal'
+  domain_type: ['all'] #List of domain types: 'all' or any domain in obs file. (e.g., airnow: epa_region, state_name, siteid, etc.) 
+  domain_name: ['CONUS'] #List of domain names. If domain_type = all domain_name is used in plot title.
+  data: ['firexaq_wrfchem_v4.2'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
+

--- a/melodies_monet/driver.py
+++ b/melodies_monet/driver.py
@@ -11,7 +11,6 @@ import numpy as np
 import datetime
 
 # from util import write_ncf
-import melodies_monet
 
 __all__ = (
     "pair",
@@ -654,7 +653,7 @@ class analysis:
                     
                                 # if aircraft (aircraft observation)
                 elif obs.obs_type.lower() == 'aircraft':
-                    
+                    from .util.tools import vert_interp
                     # convert this to pandas dataframe unless already done because second time paired this obs
                     if not isinstance(obs.obj, pd.DataFrame):
                         obs.obj = obs.obj.to_dataframe()
@@ -676,7 +675,7 @@ class analysis:
                     #Interpolate based on time in the observations
                     ds_model = ds_model.interp(time=ds_model.time_obs.squeeze())
                     
-                    paired_data = melodies_monet.util.tools.vert_interp(ds_model,obs.obj,keys+mod_vars)
+                    paired_data = vert_interp(ds_model,obs.obj,keys+mod_vars)
                     print('After pairing: ', paired_data)
                     # this outputs as a pandas dataframe.  Convert this to xarray obj
                     p = pair()
@@ -690,7 +689,7 @@ class analysis:
                     p.obj = paired_data.set_index('time').to_xarray().expand_dims('x').transpose('time','x')
                     label = "{}_{}".format(p.obs, p.model)
                     self.paired[label] = p
-                    # melodies_monet.util.write_util.write_ncf(p.obj,p.filename) # write out to file
+                    # write_util.write_ncf(p.obj,p.filename) # write out to file
                     
                 # TODO: add other network types / data types where (ie flight, satellite etc)
 

--- a/melodies_monet/util/__init__.py
+++ b/melodies_monet/util/__init__.py
@@ -1,4 +1,7 @@
 # Copyright (C) 2022 National Center for Atmospheric Research and National Oceanic and Atmospheric Administration
 # SPDX-License-Identifier: Apache-2.0
 #
+
+from . import write_util, tools
+
 __all__ = ['write_util', 'tools']

--- a/melodies_monet/util/tools.py
+++ b/melodies_monet/util/tools.py
@@ -319,3 +319,4 @@ def vert_interp(ds_model,df_obs,var_name_list):
                             on='time', direction='nearest')
 
     return final_df_model
+


### PR DESCRIPTION
- Added basic pairing functionality for aircraft observations. This was tested using firexaq aircraft observations but should function with others. 
- Added a .yaml file with a configuration for loading firexaq observations. 
- added functions to the observation and model classes (rename_vars) that will rename variables based on the .yaml. This is so that the pressure level in the model and observations can be set to a standard name ("pressure_obs" and "pressure_model"), to function with the vertical interpolation code. Additionally, nonstandard names for latitude and longitude can be renamed as needed.
- Plotting for timeseries, taylor and boxplot types all work correctly on model/aircraft paired data. Stats also works correctly on model/aircraft paired data. 