### PR TITLE
Added ability to save out and read in attributes of the analysis class (paired, models, obs).

### DIFF
--- a/melodies_monet/driver.py
+++ b/melodies_monet/driver.py
@@ -647,11 +647,9 @@ class analysis:
         if len(files)==1:
             if method=='pkl':
                 setattr(self, attr, read_pkl(files[0]))
-                 # self.paired = read_pkl(filename[0])
             elif method=='netcdf':
                 group_ds = read_grouped_ncf(files[0],xr_kws)
-                setattr(self, attr,  xarray_to_class(class_type=class_names[attr],group_ds=group_ds))
-                # self.paired = populate_class(class_type='pair',group_ds=group_ds)          
+                setattr(self, attr,  xarray_to_class(class_type=class_names[attr],group_ds=group_ds))        
         
         # If only >1 file then merge by group prior to setting
         elif len(files)>1:
@@ -673,7 +671,6 @@ class analysis:
                         attr_out[group].obj = xr.merge([attr_out[group].obj,attr_append[group].obj])
             
             setattr(self, attr,  attr_out)
-            # self.paired=paired_out
         
     
     ### TODO: Create the plotting driver (most complicated one)

--- a/melodies_monet/driver.py
+++ b/melodies_monet/driver.py
@@ -610,7 +610,72 @@ class analysis:
                     p.obj = p.fix_paired_xarray(dset=p.obj)
                     # write_util.write_ncf(p.obj,p.filename) # write out to file
                 # TODO: add other network types / data types where (ie flight, satellite etc)
+    
+    def read_saved_data(self,filenames, method, attr, xr_kws={}):
+        """Read previously saved dict containing melodies-monet data (:attr:`paired`, :attr:`models`, or :attr:`obs`)
+        from pickle file or netcdf file, populating the :attr:`paired`, :attr:`models`, or :attr:`obs` dict.
 
+        Parameters
+        ----------
+        filename : str or iterable
+            Description of parameter `filename`.
+        method : str
+            One of either 'pkl' or 'netcdf'.
+        attr : str
+            The analysis attribute that will be populated with the saved data. One of either 'paired' or 'models' or 'obs'.
+        **kwargs : optional
+            Additional keyword arguments for xr.open_dataset()
+
+        Returns
+        -------
+        None
+        """
+        if method=='pkl':
+            from .util.read_util import read_pkl
+        elif method=='netcdf':
+            from .util.read_util import read_grouped_ncf, xarray_to_class
+            
+        class_names = {'paired':'pair','models':'model','obs':'observation'}
+        
+        # if filename is a str make it a list 
+        if isinstance(filenames,str):
+            files = [filenames]
+        else:
+            files = filenames
+        
+        # If only 1 file then set directly
+        if len(files)==1:
+            if method=='pkl':
+                setattr(self, attr, read_pkl(files[0]))
+                 # self.paired = read_pkl(filename[0])
+            elif method=='netcdf':
+                group_ds = read_grouped_ncf(files[0],xr_kws)
+                setattr(self, attr,  xarray_to_class(class_type=class_names[attr],group_ds=group_ds))
+                # self.paired = populate_class(class_type='pair',group_ds=group_ds)          
+        
+        # If only >1 file then merge by group prior to setting
+        elif len(files)>1:
+            for count, file in enumerate(files):
+                if count==0:
+                    if method=='pkl':
+                        attr_out = read_pkl(file)
+                    elif method=='netcdf':
+                        group_ds = read_grouped_ncf(file,xr_kws)
+                        attr_out = xarray_to_class(class_names[attr],group_ds=group_ds) 
+                else:
+                    if method=='pkl':
+                        attr_append = read_pkl(file)
+                    elif method=='netcdf':
+                        group_ds = read_grouped_ncf(file,xr_kws)
+                        attr_append = xarray_to_class(class_names[attr],group_ds=group_ds) 
+                        
+                    for group in attr_out.keys():
+                        attr_out[group].obj = xr.merge([attr_out[group].obj,attr_append[group].obj])
+            
+            setattr(self, attr,  attr_out)
+            # self.paired=paired_out
+        
+    
     ### TODO: Create the plotting driver (most complicated one)
     # def plotting(self):
     def plotting(self):

--- a/melodies_monet/util/__init__.py
+++ b/melodies_monet/util/__init__.py
@@ -1,4 +1,4 @@
 # Copyright (C) 2022 National Center for Atmospheric Research and National Oceanic and Atmospheric Administration
 # SPDX-License-Identifier: Apache-2.0
 #
-__all__ = ['write_util', 'tools']
+__all__ = ['write_util','read_util', 'tools']

--- a/melodies_monet/util/read_util.py
+++ b/melodies_monet/util/read_util.py
@@ -1,0 +1,93 @@
+# Copyright (C) 2022 National Center for Atmospheric Research and National Oceanic and Atmospheric Administration
+# SPDX-License-Identifier: Apache-2.0
+#
+
+
+def read_pkl(filename):
+    """Function to read a pickle file containing part of the analysis class (models, obs, paired)
+
+    Parameters
+    ----------
+    filename : type
+        Description of parameter `filename`.
+        
+    Returns
+    -------
+    obj : type
+        Description of returned object.
+
+    """
+    from joblib import load
+    
+    print('Reading:', filename)
+    with open(filename, 'rb') as file:
+        obj = load(file)
+        
+    return obj
+
+def read_grouped_ncf(filename,xr_kws={}):
+    """Function to read netcdf4 files containing a part of the analysis class (models, obs, paired).
+
+    Parameters
+    ----------
+    filename : str
+        Description of parameter `filename`.
+    xr_kws : optional
+            Additional keyword arguments for xr.open_dataset()
+        
+    Returns
+    -------
+    ds_dict : type
+        Dict containing xarray datasets for each group.
+
+    """
+    import netCDF4
+    import xarray as xr
+    
+    print('Reading:', filename)
+    
+    # Get a list of netCDF groups in the file
+    ncf = netCDF4.Dataset(filename,mode='r')
+    groups = ncf.groups.keys()
+    ncf.close()
+    
+    obj = {}
+    for group in groups:
+        obj[group] = xr.open_dataset(filename,group=group,**xr_kws)
+        
+    return obj
+
+def xarray_to_class(class_type,group_ds):
+    """Remake dict containing driver class instances from dict of xarray datasets. Dict of xarray datasets must contain 
+    global attribute that contains json formatted class attributes.
+
+    Parameters
+    ----------
+    class_type : str
+        One of 'model', 'pair' or 'observation'
+    group_ds : dict
+        dict containing xarray datasets from read_grouped_ncf.
+
+    Returns
+    -------
+    class_dict
+    """
+    import json
+    from melodies_monet import driver
+    
+    class_dict = {}
+    for group in group_ds.keys():
+        if class_type == 'pair':
+            c=driver.pair()
+        elif class_type == 'model':
+            c=driver.model()
+        elif class_type == 'observation':
+            c=driver.observation()
+
+        obj_dict = json.loads(group_ds[group].attrs['dict_json'])
+        for attr in obj_dict.keys():
+            setattr(c, attr, obj_dict[attr])
+        c.obj = group_ds[group]
+        class_dict[group]=c
+
+    return class_dict

--- a/melodies_monet/util/write_util.py
+++ b/melodies_monet/util/write_util.py
@@ -22,8 +22,13 @@ def write_grouped_ncf(obj, output_name, title=''):
     """
     import pandas as pd
     import json
+    import os.path
     
     print('Writing:', output_name)
+    
+    if os.path.exists(output_name):
+        os.remove(output_name)
+    
     for group in obj.keys():
         print('Writing group:', group)
         dset=obj[group].obj

--- a/melodies_monet/util/write_util.py
+++ b/melodies_monet/util/write_util.py
@@ -4,6 +4,44 @@
 import numpy as np
 from pandas.api.types import is_float_dtype
 
+def write_grouped_ncf(obj, output_name, title=''):
+    """Function to write netcdf4 files with some compression for floats from an attribute of the
+    analysis class (models, obs, paired).
+
+    Parameters
+    ----------
+    obj : dict
+        Dict containing attribute of the driver analysis class (model, observation or paired).
+    output_name : str
+        Description of parameter `output_name`.
+
+    Returns
+    -------
+    None
+
+    """
+    import pandas as pd
+    import json
+    
+    print('Writing:', output_name)
+    for group in obj.keys():
+        print('Writing group:', group)
+        dset=obj[group].obj
+        comp = dict(zlib=True, complevel=7)
+        encoding = {}
+        for i in dset.data_vars.keys():
+            # if is_float_dtype(dset[i]):  # (dset[i].dtype != 'object') & (i != 'time') & (i != 'time_local') :
+            #     print("Compressing: {}, original_dtype: {}".format(i, dset[i].dtype))
+            #     dset[i] = compress_variable(dset[i])
+            encoding[i] = comp
+        dset.attrs['title'] = title
+        dset.attrs['format'] = 'NetCDF-4'
+        dset.attrs['date_created'] = pd.to_datetime('today').strftime('%Y-%m-%d')
+        dict_json = obj[group].__dict__.copy()
+        dict_json.pop('obj')
+        dset.attrs['dict_json'] = json.dumps(dict_json, indent = 4) 
+        # dset.to_netcdf(output_name, encoding=encoding,group=group,mode='a')
+        dset.to_netcdf(output_name, group=group, mode='a')
 
 def write_ncf(dset, output_name, title=''):
     """Function to write netcdf4 files with some compression for floats
@@ -132,3 +170,24 @@ def compress_variable(da):
     da.attrs['_FillValue'] = -1
     da.attrs['missing_value'] = -1
     return da
+
+def write_pkl(obj, output_name):
+    """Function to write a pickle file from an attribute of the analysis class (models, obs, paired)
+
+    Parameters
+    ----------
+    obj : type
+        Description of parameter `obj`.
+    output_name : str
+        Description of parameter `output_name`.
+        
+    Returns
+    -------
+    None
+
+    """
+    from joblib import dump
+    
+    print('Writing:', output_name)
+    with open(output_name, 'wb') as outp:
+        dump(obj, outp)


### PR DESCRIPTION
- Added functions to save out attributes of the analysis class (paired, models, obs) in both pickle and netcdf format. Netdf files are saved such that groups within the attribute (i.e. a single model/obs pair) are saved as a group within the netcdf file. Further groups are added to the netcdf as necessary. The class attributes are saved to a json formatted string in the netcdf global attributes for each group.
- Added functions to read in attributes of the analysis class (paired, models, obs) that have been saved in both pickle and netcdf format. For netcdf files, the class attributes are repopulated from a json formatted string in the netcdf global attributes for each group. The appropriate analysis attribute is then set with the data (paired, model, obs)
- If multiple files are specified for read in, the read_saved_data function will automatically merge the datasets before setting the analysis attribute specified. 

In progress:
- need to test that reading in models and obs attributes functions correctly.
- need to test that reading in multiple netcdf files functions correctly.
- Netcdf files do not work correctly when using util.write_util.compress_variable so need to debug this