### PR TITLE
CLI updates - get AERONET and AirNow data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
           cd docs/examples
           melodies-monet --version
           python -m melodies_monet --version
-          melodies-monet control_idealized.yaml
+          melodies-monet run control_idealized.yaml
           cd -
 
   docs:

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -2,6 +2,12 @@
 Command Line Interface
 ======================
 
+**Subcommands**
+
+* `run <#melodies-monet-run>`_ -- run a control file
+* `get-aeronet <#melodies-monet-get-aeronet>`_ -- get AirNow data
+* `get-airnow <#melodies-monet-get-airnow>`_ -- get AERONET data
+
 .. click:: melodies_monet._cli:_typer_click_object
    :prog: melodies-monet
    :nested: full

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -2,11 +2,29 @@
 Command Line Interface
 ======================
 
+Installing :mod:`melodies_monet` provides a command line interface (CLI):
+``melodies-monet``.
+
+For example, you can use the CLI to run control files without writing
+any Python code::
+
+    melodies-monet run control.yml
+
 **Subcommands**
 
-* `run <#melodies-monet-run>`_ -- run a control file
-* `get-aeronet <#melodies-monet-get-aeronet>`_ -- get AirNow data
-* `get-airnow <#melodies-monet-get-airnow>`_ -- get AERONET data
+* |run|_ -- run a control file
+* |get-airnow|_ -- get AirNow data
+* |get-aeronet|_ -- get AERONET data
+
+.. |run| replace:: ``run``
+.. _run: #melodies-monet-run
+
+.. |get-airnow| replace:: ``get-airnow``
+.. _get-airnow: #melodies-monet-get-airnow
+
+.. |get-aeronet| replace:: ``get-aeronet``
+.. _get-aeronet: #melodies-monet-get-aeronet
+
 
 .. click:: melodies_monet._cli:_typer_click_object
    :prog: melodies-monet

--- a/docs/develop/developers_guide.rst
+++ b/docs/develop/developers_guide.rst
@@ -74,7 +74,7 @@ these instructions:
 
        $ conda create --name melodies-monet python=3.9
        $ conda activate melodies-monet
-       $ conda install -y -c conda-forge pyyaml monet monetio netcdf4 wrf-python click pooch jupyterlab
+       $ conda install -y -c conda-forge pyyaml monet monetio netcdf4 wrf-python typer rich pooch jupyterlab
 
 (b) Clone [#clone]_ and link the latest development versions of MONET and MONETIO from GitHub to
     your conda environment::

--- a/docs/tutorial/installation.rst
+++ b/docs/tutorial/installation.rst
@@ -14,7 +14,8 @@ Optional dependencies
 
 - ``netcdf4`` (`from Unidata <https://unidata.github.io/netcdf4-python/>`__; most likely needed for reading model/obs datasets)
 - ``wrf-python`` (needed in order to use the WRF-Chem reader)
-- ``click`` (to use the :doc:`/cli`)
+- ``typer`` (to use the :doc:`/cli`;
+  add ``rich`` `for <https://typer.tiangolo.com/release-notes/#060>`__ fancy tracebacks and ``--help``)
 - ``pooch`` (to enable automatic downloading of :doc:`tutorial datasets </examples/tutorial-data>`)
 
 .. _user-install-instructions:
@@ -33,7 +34,7 @@ First create and activate a conda environment::
 
 Add dependencies from conda-forge::
 
-    $ conda install -y -c conda-forge pyyaml monet monetio netcdf4 wrf-python click pooch
+    $ conda install -y -c conda-forge pyyaml monet monetio netcdf4 wrf-python typer rich pooch
 
 Now, install the stable branch of MELODIES MONET to the environment::
 

--- a/examples/submit_jobs/submit_hera_cli.sh
+++ b/examples/submit_jobs/submit_hera_cli.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -l
+
+#SBATCH --qos batch
+#SBATCH --job-name=mm_eval
+#SBATCH --partition=bigmem
+#SBATCH --time=05:00:00
+#SBATCH --ntasks=5
+# -- Update to your account number
+#SBATCH --account=rcm2
+
+# -- Update to the location of your conda environment
+source /scratch2/BMC/rcm1/rhs/miniconda3/bin/activate mm_dev_cli
+
+# -- Run MELODIES MONET through a command line call instead
+cd /scratch2/BMC/rcm1/rhs/MONET/main/wrf-chem/qindan_test/
+melodies-monet run control_wrfchem_cli.yaml

--- a/melodies_monet/_cli.py
+++ b/melodies_monet/_cli.py
@@ -135,7 +135,7 @@ def get_aeronet(
     out_name: str = typer.Option(None, "-o",
         help=(
             "Output file name (or full/relative path). "
-            "By default the name is generated like 'AERONET_<product>_<start date>_<end date>.nc'"
+            "By default the name is generated like 'AERONET_<product>_<start-date>_<end-date>.nc'"
         )
     ),
     dst: Path = typer.Option(".", "-d", "--dst", help=(

--- a/melodies_monet/_cli.py
+++ b/melodies_monet/_cli.py
@@ -226,6 +226,8 @@ def get_aeronet(
     ]
 
     with _timer("Forming xarray Dataset"):
+        df = df.dropna(subset=["latitude", "longitude"])
+
         # Site-specific variables should only vary in x.
         # Here we take the first non-NaN value (should all be same).
         ds_site = (
@@ -238,7 +240,6 @@ def get_aeronet(
 
         ds = (
             df
-            .dropna(subset=["latitude", "longitude"])
             .set_index(["time", "siteid"])
             .to_xarray()
             .rename_dims(siteid="x")

--- a/melodies_monet/_cli.py
+++ b/melodies_monet/_cli.py
@@ -137,7 +137,11 @@ def get_aeronet(
     start_date: str = typer.Option(..., "-s", "--start-date", help="Start date."),
     end_date: str = typer.Option(..., "-e", "--end-date", help="End date."),
     daily: bool = typer.Option(False, help="Whether to retrieve the daily averaged data product."),
-    freq: str = typer.Option("H", "-f", "--freq", help="Frequency to resample to."),
+    freq: str = typer.Option("H", "-f", "--freq", help=(
+            "Frequency to resample to. "
+            "Mean is used to reduce the time groups (as opposed to nearest, e.g.)."
+        )
+    ),
     interp_to: str = typer.Option(None, "--interp-to", help=(
             "Wavelength(s) to interpolate the AOD values to (micron). "
             "Separate with commas to specify multiple. "

--- a/melodies_monet/_cli.py
+++ b/melodies_monet/_cli.py
@@ -155,6 +155,12 @@ def get_aeronet(
             "if using default `out_name`)."
         )
     ),
+    compress: bool = typer.Option(True, help=(
+            "If true, pack float to int and apply compression using zlib with complevel 7. "
+            "This can take time if the dataset is large, but can lead to "
+            "significant space savings."
+        )
+    ),
     num_workers: int = typer.Option(1, "-n", "--num-workers", help="Number of download workers."),
     verbose: bool = typer.Option(False),
     debug: bool = typer.Option(
@@ -245,7 +251,10 @@ def get_aeronet(
         )
 
     with _timer("Writing netCDF file"):
-        write_ncf(ds, dst / out_name, verbose=verbose)
+        if compress:
+            write_ncf(ds, dst / out_name, verbose=verbose)
+        else:
+            ds.to_netcdf(dst / out_name)
 
 
 cli = app

--- a/melodies_monet/_cli.py
+++ b/melodies_monet/_cli.py
@@ -70,17 +70,23 @@ def _version_callback(value: bool):
 app = typer.Typer()
 
 
-@app.command(name="run")
+@app.callback()
 def main(
+    version: bool = typer.Option(
+        False, "--version/", help="Print version.", callback=_version_callback, is_eager=True
+    ),
+):
+    """MELODIES MONET"""
+
+
+@app.command()
+def run(
     control: str = typer.Argument(
         ...,
         help="Path to the control file to use.", 
     ),
     debug: bool = typer.Option(
         False, "--debug/", help="Print more messages (including full tracebacks)."
-    ),
-    version: bool = typer.Option(
-        False, "--version/", help="Print version.", callback=_version_callback, is_eager=True
     ),
 ):
     """Run MELODIES MONET as described in the control file CONTROL."""

--- a/melodies_monet/_cli.py
+++ b/melodies_monet/_cli.py
@@ -70,7 +70,7 @@ def _version_callback(value: bool):
 app = typer.Typer()
 
 
-@app.command()
+@app.command(name="run")
 def main(
     control: str = typer.Argument(
         ...,
@@ -124,6 +124,30 @@ def main(
     if an.control_dict.get("stats") is not None:
         with _timer("Computing and saving statistics"):
             an.stats()
+
+
+@app.command()
+def get_aeronet(
+    start_date: str = typer.Option(..., "-s", "--start-date", help="Start date."),
+    end_date: str = typer.Option(..., "-e", "--end-date", help="End date."),
+    daily: bool = typer.Option(False, help="Whether to retrieve the daily averaged data product."),
+    freq: str = typer.Option(None, "-f", "--freq", help="Frequency to resample to."),
+    out_name: str = typer.Option(None, "-o",
+        help=(
+            "Output file name (or full/relative path). "
+            "By default the name is generated like 'AERONET_<product>_<start date>_<end date>.nc'"
+        )
+    ),
+    dst: Path = typer.Option(".", "-d", "--dst", help=(
+            "Destination directory (to control output location "
+            "if using default out name)."
+        )
+    ),
+    num_workers: int = typer.Option(1, "-n", "--num-workers", help="Number of download workers."),
+):
+    """Download AERONET data using monetio and reformat for MM usage."""
+    ...
+    
 
 
 cli = app

--- a/melodies_monet/_cli.py
+++ b/melodies_monet/_cli.py
@@ -260,6 +260,167 @@ def get_aeronet(
             ds.to_netcdf(dst / out_name)
 
 
+@app.command()
+def get_airnow(
+    start_date: str = typer.Option(..., "-s", "--start-date", help="Start date."),
+    end_date: str = typer.Option(..., "-e", "--end-date", help="End date."),
+    daily: bool = typer.Option(False, help=(
+            "Whether to retrieve the daily averaged data product. "
+            "By default, the hourly data is fetched."
+        )
+    ),
+    out_name: str = typer.Option(None, "-o",
+        help=(
+            "Output file name (or full/relative path). "
+            "By default the name is generated like 'AERONET_<product>_<start-date>_<end-date>.nc'"
+        )
+    ),
+    dst: Path = typer.Option(".", "-d", "--dst", help=(
+            "Destination directory (to control output location "
+            "if using default `out_name`)."
+        )
+    ),
+    compress: bool = typer.Option(True, help=(
+            "If true, pack float to int and apply compression using zlib with complevel 7. "
+            "This can take time if the dataset is large, but can lead to "
+            "significant space savings."
+        )
+    ),
+    num_workers: int = typer.Option(1, "-n", "--num-workers", help="Number of download workers."),
+    verbose: bool = typer.Option(False),
+    debug: bool = typer.Option(
+        False, "--debug/", help="Print more messages (including full tracebacks)."
+    ),
+):
+    """Download AirNow data using monetio and reformat for MM usage.
+    
+    The date range used is closed on both sides.
+    """
+    import warnings
+
+    import monetio as mio
+    import pandas as pd
+
+    from .util.write_util import write_ncf
+
+    global DEBUG
+
+    DEBUG = debug
+
+    typer.echo(HEADER)
+
+    start_date = pd.Timestamp(start_date)
+    end_date = pd.Timestamp(end_date)
+    dates = pd.date_range(start_date, end_date, freq="H")
+    print(dates)
+
+    # Set destination and file name
+    fmt = r"%Y%m%d"
+    if out_name is None:
+        out_name = f"AERONET_L15_{start_date:{fmt}}_{end_date:{fmt}}.nc"
+    else:
+        p = Path(out_name)
+        if p.name == out_name:
+            # `out_name` is just the file name
+            out_name = p.name
+        else:
+            # `out_name` has path
+            if dst != Path("."):
+                typer.echo(f"warning: overriding `dst` setting {dst.as_posix()!r} with `out_name` {p.as_posix()!r}")
+            dst = p.parent
+            out_name = p.name
+
+    with _timer("Fetching data with monetio"):
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="The (error|warn)_bad_lines argument has been deprecated"
+            )
+            df = mio.airnow.add_data(
+                dates,
+                download=False,
+                wide_fmt=True,  # column for each variable
+                n_procs=num_workers,
+                daily=daily,
+            )
+
+    print(len(df), "columns")
+    print(df.columns.tolist())
+    print(df.head(3))
+
+    with _timer("Forming xarray Dataset"):
+        df = df.dropna(subset=["latitude", "longitude"])
+
+        site_vns = [
+            "site",
+            "siteid",
+            "utcoffset",
+            "latitude",
+            "longitude",
+            "cmsa_name",
+            "msa_code",
+            "msa_name",
+            "state_name",
+            "epa_region",
+        ]
+        # NOTE: time_local not included since it varies in time as well
+        if daily:
+            site_vns.remove("utcoffset")  # not present in the daily data product
+
+        ds_site = (
+            df[site_vns]
+            .groupby("siteid")
+            .first()
+            .to_xarray()
+            .rename_dims(siteid="x")
+        )
+
+        # Extract units info so we can add as attrs
+        unit_suff = "_unit"
+        unit_cols = [n for n in df.columns if n.endswith(unit_suff)]
+        assert (df[unit_cols].nunique() == 1).all()
+        units = df[unit_cols][~df[unit_cols].isnull()].iloc[0].to_dict()
+
+        cols = [n for n in df.columns if not n.endswith(unit_suff)]
+        ds = (
+            df[cols]
+            .set_index(["time", "siteid"])
+            .to_xarray()
+            .rename_dims(siteid="x")
+            .drop_vars(site_vns)
+            .merge(ds_site)
+            .set_coords(["latitude", "longitude"])
+            .assign(x=range(ds_site.dims["x"]))
+        )
+
+        # Add units
+        for k, u in units.items():
+            vn = k[:-len(unit_suff)]
+            ds[vn].attrs.update(units=u)
+
+        # Fill in local time array
+        # (in the df, not all sites have rows for all times, so we have NaTs at this point)
+        if not daily:
+            ds["time_local"] = ds.time + ds.utcoffset.astype("timedelta64[h]")
+
+        # Expand
+        ds = (
+            ds
+            .expand_dims("y")
+            .transpose("time", "y", "x")
+        )
+
+    print(ds)
+    if not daily:
+        print(ds.time_local)
+
+    with _timer("Writing netCDF file"):
+        if compress:
+            write_ncf(ds, dst / out_name, verbose=verbose)
+        else:
+            ds.to_netcdf(dst / out_name)
+
+
 cli = app
 
 _typer_click_object = typer.main.get_command(app)  # for sphinx-click in docs

--- a/melodies_monet/_cli.py
+++ b/melodies_monet/_cli.py
@@ -248,7 +248,7 @@ def get_aeronet(
     
     # Write the file
     t = ds.expand_dims("y").transpose("time", "y", "x")
-    write_ncf(t, dst / out_name)
+    write_ncf(t, dst / out_name, verbose=verbose)
 
 
 cli = app

--- a/melodies_monet/_cli.py
+++ b/melodies_monet/_cli.py
@@ -138,6 +138,12 @@ def get_aeronet(
     end_date: str = typer.Option(..., "-e", "--end-date", help="End date."),
     daily: bool = typer.Option(False, help="Whether to retrieve the daily averaged data product."),
     freq: str = typer.Option(None, "-f", "--freq", help="Frequency to resample to."),
+    interp_to: str = typer.Option(None, "--interp-to", help=(
+            "Wavelength(s) to interpolate the AOD values to (micron). "
+            "Separate with commas to specify multiple. "
+            "Note that this functionality requires pytspack."
+        )
+    ),
     out_name: str = typer.Option(None, "-o",
         help=(
             "Output file name (or full/relative path). "
@@ -195,11 +201,10 @@ def get_aeronet(
             dst = p.parent
             out_name = p.name
 
-    #standard_wavelengths = np.array([0.34, 0.44, 0.55, 0.66, 0.86, 1.63, 11.1]) * 1000.0
-    # ^ some of these overlap with existing wls in the dataset
-    #   so the later `dfp.to_xarray()` fails since we get duplicate column names
-    interp_to = np.array([0.55]) * 1000.0
-    # ^ only really need 550 nm for the comparison to UFS-Aerosol
+    if interp_to is not None:
+        interp_to = np.array([float(x.strip()) for x in interp_to.strip().split(",")])
+        interp_to *= 1000  # um -> nm
+
     try:
         df = mio.aeronet.add_data(
             dates,

--- a/melodies_monet/_cli.py
+++ b/melodies_monet/_cli.py
@@ -135,14 +135,21 @@ def run(
 _DATE_FMT_NOTE = (
     "Date can be in any format accepted by `pandas.date_range()`, "
     "e.g., 'YYYY-MM-DD', or 'M/D/YYYY'. "
-    "Time other than 0 UTC can be specified by adding trailing ' HH[:MM[:SS]]'."
+    "Time other than 0 UTC can be specified by adding trailing ' HH[:MM[:SS]]', "
+    "but this might not have an effect on the output."
+)
+_DATE_END_NOTE = (
+    "As not specifying time implies 0 UTC, "
+    "to get the full last day for hourly data, you should specify hour, e.g., append ' 23' "
+    "or increase end date by one day. "
+    "For daily data, this is not necessary."
 )
 
 
 @app.command()
 def get_aeronet(
     start_date: str = typer.Option(..., "-s", "--start-date", help=f"Start date. {_DATE_FMT_NOTE}"),
-    end_date: str = typer.Option(..., "-e", "--end-date", help=f"End date. {_DATE_FMT_NOTE}"),
+    end_date: str = typer.Option(..., "-e", "--end-date", help=f"End date. {_DATE_FMT_NOTE} {_DATE_END_NOTE}"),
     daily: bool = typer.Option(False, help="Whether to retrieve the daily averaged data product."),
     freq: str = typer.Option("H", "-f", "--freq", help=(
             "Frequency to resample to. "
@@ -153,7 +160,8 @@ def get_aeronet(
             "Wavelength(s) to interpolate the AOD values to (unit: micron). "
             "Separate with commas to specify multiple. "
             "Examples: '0.55' (550 nm), '0.55,0.7,1.0'. "
-            "Note that this functionality requires pytspack."
+            "Note that this functionality requires pytspack "
+            "(https://github.com/noaa-oar-arl/pytspack)."
         )
     ),
     out_name: str = typer.Option(None, "-o",
@@ -275,7 +283,7 @@ def get_aeronet(
 @app.command()
 def get_airnow(
     start_date: str = typer.Option(..., "-s", "--start-date", help=f"Start date. {_DATE_FMT_NOTE}"),
-    end_date: str = typer.Option(..., "-e", "--end-date", help=f"End date. {_DATE_FMT_NOTE}"),
+    end_date: str = typer.Option(..., "-e", "--end-date", help=f"End date. {_DATE_FMT_NOTE} {_DATE_END_NOTE}"),
     daily: bool = typer.Option(False, help=(
             "Whether to retrieve the daily averaged data product. "
             "By default, the hourly data is fetched."
@@ -304,10 +312,7 @@ def get_airnow(
         False, "--debug/", help="Print more messages (including full tracebacks)."
     ),
 ):
-    """Download AirNow data using monetio and reformat for MM usage.
-    
-    The date range used is closed on both sides.
-    """
+    """Download AirNow data using monetio and reformat for MM usage."""
     import warnings
 
     import monetio as mio

--- a/melodies_monet/_cli.py
+++ b/melodies_monet/_cli.py
@@ -150,8 +150,9 @@ def get_aeronet(
         )
     ),
     interp_to: str = typer.Option(None, "--interp-to", help=(
-            "Wavelength(s) to interpolate the AOD values to (micron). "
+            "Wavelength(s) to interpolate the AOD values to (unit: micron). "
             "Separate with commas to specify multiple. "
+            "Examples: '0.55' (550 nm), '0.55,0.7,1.0'. "
             "Note that this functionality requires pytspack."
         )
     ),

--- a/melodies_monet/_cli.py
+++ b/melodies_monet/_cli.py
@@ -132,10 +132,17 @@ def run(
             an.stats()
 
 
+_DATE_FMT_NOTE = (
+    "Date can be in any format accepted by `pandas.date_range()`, "
+    "e.g., 'YYYY-MM-DD', or 'M/D/YYYY'. "
+    "Time other than 0 UTC can be specified by adding trailing ' HH[:MM[:SS]]'."
+)
+
+
 @app.command()
 def get_aeronet(
-    start_date: str = typer.Option(..., "-s", "--start-date", help="Start date."),
-    end_date: str = typer.Option(..., "-e", "--end-date", help="End date."),
+    start_date: str = typer.Option(..., "-s", "--start-date", help=f"Start date. {_DATE_FMT_NOTE}"),
+    end_date: str = typer.Option(..., "-e", "--end-date", help=f"End date. {_DATE_FMT_NOTE}"),
     daily: bool = typer.Option(False, help="Whether to retrieve the daily averaged data product."),
     freq: str = typer.Option("H", "-f", "--freq", help=(
             "Frequency to resample to. "
@@ -266,8 +273,8 @@ def get_aeronet(
 
 @app.command()
 def get_airnow(
-    start_date: str = typer.Option(..., "-s", "--start-date", help="Start date."),
-    end_date: str = typer.Option(..., "-e", "--end-date", help="End date."),
+    start_date: str = typer.Option(..., "-s", "--start-date", help=f"Start date. {_DATE_FMT_NOTE}"),
+    end_date: str = typer.Option(..., "-e", "--end-date", help=f"End date. {_DATE_FMT_NOTE}"),
     daily: bool = typer.Option(False, help=(
             "Whether to retrieve the daily averaged data product. "
             "By default, the hourly data is fetched."

--- a/melodies_monet/_cli.py
+++ b/melodies_monet/_cli.py
@@ -167,12 +167,12 @@ def get_aeronet(
     out_name: str = typer.Option(None, "-o",
         help=(
             "Output file name (or full/relative path). "
-            "By default the name is generated like 'AERONET_<product>_<start-date>_<end-date>.nc'"
+            "By default the name is generated like 'AERONET_<product>_<start-date>_<end-date>.nc'."
         )
     ),
     dst: Path = typer.Option(".", "-d", "--dst", help=(
             "Destination directory (to control output location "
-            "if using default `out_name`)."
+            "if using default output file name)."
         )
     ),
     compress: bool = typer.Option(True, help=(
@@ -292,12 +292,12 @@ def get_airnow(
     out_name: str = typer.Option(None, "-o",
         help=(
             "Output file name (or full/relative path). "
-            "By default the name is generated like 'AirNow_<start-date>_<end-date>.nc'"
+            "By default the name is generated like 'AirNow_<start-date>_<end-date>.nc'."
         )
     ),
     dst: Path = typer.Option(".", "-d", "--dst", help=(
             "Destination directory (to control output location "
-            "if using default `out_name`)."
+            "if using default output file name)."
         )
     ),
     compress: bool = typer.Option(True, help=(

--- a/melodies_monet/_cli.py
+++ b/melodies_monet/_cli.py
@@ -178,6 +178,8 @@ def get_aeronet(
 
     DEBUG = debug
 
+    typer.echo(HEADER)
+
     start_date = pd.Timestamp(start_date)
     end_date = pd.Timestamp(end_date)
     dates = pd.date_range(start_date, end_date, freq="D")
@@ -194,7 +196,7 @@ def get_aeronet(
         else:
             # `out_name` has path
             if dst != Path("."):
-                print(f"warning: overriding `dst` setting {dst.as_posix()!r} with `out_name` {p.as_posix()!r}")
+                typer.echo(f"warning: overriding `dst` setting {dst.as_posix()!r} with `out_name` {p.as_posix()!r}")
             dst = p.parent
             out_name = p.name
 
@@ -214,7 +216,7 @@ def get_aeronet(
             )
         except ValueError:
             if daily and interp_to is not None:
-                print("Note that using interp with the daily product requires monetio >0.2.2")
+                typer.echo("Note that using interp with the daily product requires monetio >0.2.2")
             raise
   
     site_vns = [

--- a/melodies_monet/_cli.py
+++ b/melodies_monet/_cli.py
@@ -237,14 +237,14 @@ def get_aeronet(
             .groupby("siteid")
             .first()  # TODO: would be nice to confirm unique-ness
             .to_xarray()
-            .rename_dims(siteid="x")
+            .swap_dims(siteid="x")
         )
 
         ds = (
             df
             .set_index(["time", "siteid"])
             .to_xarray()
-            .rename_dims(siteid="x")
+            .swap_dims(siteid="x")
             .drop_vars(site_vns)
             .merge(ds_site)
             .set_coords(site_vns)
@@ -384,7 +384,7 @@ def get_airnow(
             .groupby("siteid")
             .first()
             .to_xarray()
-            .rename_dims(siteid="x")
+            .swap_dims(siteid="x")
         )
 
         # Extract units info so we can add as attrs
@@ -398,7 +398,7 @@ def get_airnow(
             df[cols]
             .set_index(["time", "siteid"])
             .to_xarray()
-            .rename_dims(siteid="x")
+            .swap_dims(siteid="x")
             .drop_vars(site_vns)
             .merge(ds_site)
             .set_coords(["latitude", "longitude"])

--- a/melodies_monet/_cli.py
+++ b/melodies_monet/_cli.py
@@ -272,7 +272,7 @@ def get_airnow(
     out_name: str = typer.Option(None, "-o",
         help=(
             "Output file name (or full/relative path). "
-            "By default the name is generated like 'AERONET_<product>_<start-date>_<end-date>.nc'"
+            "By default the name is generated like 'AirNow_<start-date>_<end-date>.nc'"
         )
     ),
     dst: Path = typer.Option(".", "-d", "--dst", help=(
@@ -319,7 +319,7 @@ def get_airnow(
     # Set destination and file name
     fmt = r"%Y%m%d"
     if out_name is None:
-        out_name = f"AERONET_L15_{start_date:{fmt}}_{end_date:{fmt}}.nc"
+        out_name = f"AirNow_{start_date:{fmt}}_{end_date:{fmt}}.nc"
     else:
         p = Path(out_name)
         if p.name == out_name:

--- a/melodies_monet/_cli.py
+++ b/melodies_monet/_cli.py
@@ -137,7 +137,7 @@ def get_aeronet(
     start_date: str = typer.Option(..., "-s", "--start-date", help="Start date."),
     end_date: str = typer.Option(..., "-e", "--end-date", help="End date."),
     daily: bool = typer.Option(False, help="Whether to retrieve the daily averaged data product."),
-    freq: str = typer.Option(None, "-f", "--freq", help="Frequency to resample to."),
+    freq: str = typer.Option("H", "-f", "--freq", help="Frequency to resample to."),
     interp_to: str = typer.Option(None, "--interp-to", help=(
             "Wavelength(s) to interpolate the AOD values to (micron). "
             "Separate with commas to specify multiple. "

--- a/melodies_monet/tests/test_get_data_cli.py
+++ b/melodies_monet/tests/test_get_data_cli.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 National Center for Atmospheric Research and National Oceanic and Atmospheric Administration
+# SPDX-License-Identifier: Apache-2.0
+#
 """
 Check for consistency with the tutorial datasets and that options work.
 """

--- a/melodies_monet/tests/test_get_data_cli.py
+++ b/melodies_monet/tests/test_get_data_cli.py
@@ -1,0 +1,36 @@
+"""
+Check for consistency with the tutorial datasets and that options work.
+"""
+import subprocess
+
+import numpy as np
+import xarray as xr
+
+from melodies_monet.tutorial import fetch_example
+
+ds0_aeronet = xr.open_dataset(fetch_example("aeronet:2019-09"))
+
+
+def test_get_aeronet(tmp_path):
+    fn = "x.nc"
+    cmd = [
+        "melodies-monet", "get-aeronet",
+        "-s", "2019-09-01", "-e", "2019-09-02",
+        "--dst", tmp_path.as_posix(), "-o", fn,
+        "--no-compress",
+        # TODO: compress doesn't work with current xarray (starting with v2022.06)
+    ]
+    subprocess.run(cmd, check=True)
+
+    # To compare, need to have site ID as dim, not made-up integer dim 'x'
+    # since positions may differ due to NaN-lat/lon dropping or such
+    ds = xr.open_dataset(tmp_path / fn).squeeze().swap_dims(x="siteid")
+    ds0 = ds0_aeronet.sel(time=ds.time).squeeze().swap_dims(x="siteid")
+    # TODO: seems original loading missing value as -1 (on purpose, due to compress routine)
+    
+    assert not ds.identical(ds0)
+    assert ds.time.equals(ds0.time)
+    # assert (np.abs(ds.aod_551nm - ds0.aod_551nm) < 1e-9).all()
+    assert (np.abs(ds.aod_551nm - ds0.aod_551nm).to_series().dropna() < 1e-9).all()
+    # - Many more site IDs in ds0 (400 vs 283), and one that is in ds but not ds0
+    # - In the above, only two sites

--- a/melodies_monet/tests/test_get_data_cli.py
+++ b/melodies_monet/tests/test_get_data_cli.py
@@ -12,6 +12,7 @@ import xarray as xr
 from melodies_monet.tutorial import fetch_example
 
 ds0_aeronet = xr.open_dataset(fetch_example("aeronet:2019-09"))
+ds0_airnow = xr.open_dataset(fetch_example("airnow:2019-09"))
 
 
 def test_get_aeronet(tmp_path):
@@ -21,7 +22,6 @@ def test_get_aeronet(tmp_path):
         "-s", "2019-09-01", "-e", "2019-09-02",
         "--dst", tmp_path.as_posix(), "-o", fn,
         "--no-compress",
-        # TODO: compress doesn't work with current xarray (starting with v2022.06)
     ]
     subprocess.run(cmd, check=True)
 
@@ -37,3 +37,24 @@ def test_get_aeronet(tmp_path):
     assert (np.abs(ds.aod_551nm - ds0.aod_551nm).to_series().dropna() < 1e-9).all()
     # - Many more site IDs in ds0 (400 vs 283), and one that is in ds but not ds0
     # - In the above, only two sites
+
+
+def test_get_airnow(tmp_path):
+    fn = "x.nc"
+    cmd = [
+        "melodies-monet", "get-airnow",
+        "-s", "2019-09-01", "-e", "2019-09-02",
+        "--dst", tmp_path.as_posix(), "-o", fn,
+        "--no-compress",
+    ]
+    subprocess.run(cmd, check=True)
+
+    ds = xr.open_dataset(tmp_path / fn).squeeze().swap_dims(x="siteid")
+    ds0 = ds0_airnow.sel(time=ds.time).squeeze().swap_dims(x="siteid")
+
+    assert ds.time.equals(ds0.time)
+
+    for vn in ["NO2", "OZONE", "PM2.5"]:
+        ds0[vn] = ds0[vn].where(ds0[vn] != -1)
+        ds[vn] = ds[vn].where(~ ((ds[vn] == 0) & (ds0[vn] != 0)))
+        assert (np.abs((ds[vn] - ds0[vn]) / ds0[vn]).to_series().dropna() < 2e-6).all()

--- a/melodies_monet/tests/test_get_data_cli.py
+++ b/melodies_monet/tests/test_get_data_cli.py
@@ -58,3 +58,27 @@ def test_get_airnow(tmp_path):
         ds0[vn] = ds0[vn].where(ds0[vn] != -1)
         ds[vn] = ds[vn].where(~ ((ds[vn] == 0) & (ds0[vn] != 0)))
         assert (np.abs((ds[vn] - ds0[vn]) / ds0[vn]).to_series().dropna() < 2e-6).all()
+        assert (np.abs(ds[vn] - ds0[vn]).to_series().dropna() < 3e-7).all()
+
+
+def test_get_airnow_comp(tmp_path):
+    fn = "x.nc"
+    cmd = [
+        "melodies-monet", "get-airnow",
+        "-s", "2019-09-01", "-e", "2019-09-02",
+        "--dst", tmp_path.as_posix(), "-o", fn,
+        "--compress",
+    ]
+    subprocess.run(cmd, check=True)
+
+    ds = xr.open_dataset(tmp_path / fn).squeeze().swap_dims(x="siteid")
+    ds0 = ds0_airnow.sel(time=ds.time).squeeze().swap_dims(x="siteid")
+
+    assert ds.time.equals(ds0.time)
+
+    for vn in ["NO2", "OZONE", "PM2.5"]:
+        ds0[vn] = ds0[vn].where(ds0[vn] != -1)
+        ds[vn] = ds[vn].where(ds[vn] != -1)
+        ds[vn] = ds[vn].where(~ ((ds[vn] == 0) & (ds0[vn] != 0)))
+        # assert (np.abs((ds[vn] - ds0[vn]) / ds0[vn]).to_series().dropna() < 2e-6).all()
+        assert (np.abs(ds[vn] - ds0[vn]).to_series().dropna() < 3e-7).all()

--- a/melodies_monet/util/write_util.py
+++ b/melodies_monet/util/write_util.py
@@ -5,7 +5,7 @@ import numpy as np
 from pandas.api.types import is_float_dtype
 
 
-def write_ncf(dset, output_name, title=''):
+def write_ncf(dset, output_name, title='', *, verbose=True):
     """Function to write netcdf4 files with some compression for floats
 
     Parameters
@@ -23,12 +23,14 @@ def write_ncf(dset, output_name, title=''):
     """
     import pandas as pd
 
-    print('Writing:', output_name)
+    if verbose:
+        print('Writing:', output_name)
     comp = dict(zlib=True, complevel=7)
     encoding = {}
     for i in dset.data_vars.keys():
         if is_float_dtype(dset[i]):  # (dset[i].dtype != 'object') & (i != 'time') & (i != 'time_local') :
-            print("Compressing: {}, original_dtype: {}".format(i, dset[i].dtype))
+            if verbose:
+                print("Compressing: {}, original dtype: {}".format(i, dset[i].dtype))
             dset[i] = compress_variable(dset[i])
         encoding[i] = comp
     dset.attrs['title'] = title


### PR DESCRIPTION
Adding (sub-)commands for downloading AERONET and AirNow.
* [x] AERONET download + format tool
* [x] Fix AERONET `daily` option with interp (raise error gracefully if monetio <= than current release)
* [x] AirNow download + format tool
* [x] Fix CLI doc if necessary
* [x] Change install doc reqs for CLI to `typer` instead of `click` and mention `rich` for color

#80 Added a command line interface (CLI) for running a MM control file, including typical steps that would be done if using the MM API. This PR adds some subcommands, allowing the MM CLI to do other things (download and format AERONET and AirNow data for use in MM). To get the previous behavior, you now have to use the `run` subcommand, i.e. `melodies-monet control.yml` ⟶ `melodies-monet run control.yml`, which makes more sense anyway.

Related to https://github.com/NOAA-CSL/MELODIES-MONET/issues/117, resolves partially https://github.com/NOAA-CSL/MELODIES-MONET/issues/118