### PR TITLE
fix colormap and pandas issues with pkg version updates

### DIFF
--- a/melodies_monet/plots/surfplots.py
+++ b/melodies_monet/plots/surfplots.py
@@ -114,26 +114,16 @@ def new_color_map():
                            bottom(np.linspace(0, 1, 128))))
     return ListedColormap(newcolors, name='OrangeBlue')
 
-def new_color_map2():
-    """
-    # JianHe: create new colors here, fix for mpl v3.6+
-    Creates new color map for difference plots
-       
-    Returns
-    -------
-    colormap
-        Orange and blue color map
-
-    """
-    _cmap_name = "OrangeBlue"
+# Register the custom cmap
+_cmap_name = "OrangeBlue"
+try:
+    plt.get_cmap(_cmap_name)
+except ValueError:
+    _cmap = new_color_map()
     try:
-        return(plt.get_cmap(_cmap_name))
-    except ValueError:
-        _cmap = new_color_map()
-        try:
-            return(mpl.colormaps.register(_cmap))  # mpl 3.6+
-        except AttributeError:
-            return(mpl.cm.register_cmap(cmap=_cmap))  # old method
+        mpl.colormaps.register(_cmap)  # mpl 3.6+
+    except AttributeError:
+        mpl.cm.register_cmap(cmap=_cmap)  # old method
 
 def map_projection(f):
     """Defines map projection. This needs updating to make it more generic.
@@ -322,7 +312,7 @@ def make_spatial_bias(df, df_reg=None, column_o=None, label_o=None, column_m=Non
         #and then uses -1*val_max value for the minimum.
         ax = monet.plots.sp_scatter_bias(
             df_mean, col1=column_o+'_reg', col2=column_m+'_reg', map_kwargs=map_kwargs,val_max=vdiff,
-            cmap=new_color_map2(), edgecolor='k',linewidth=.8)
+            cmap="OrangeBlue", edgecolor='k',linewidth=.8)
     else:
         # JianHe: include options for percentile calculation (set in yaml file)
         if ptile is None:
@@ -334,7 +324,7 @@ def make_spatial_bias(df, df_reg=None, column_o=None, label_o=None, column_m=Non
         #and then uses -1*val_max value for the minimum.
         ax = monet.plots.sp_scatter_bias(
             df_mean, col1=column_o, col2=column_m, map_kwargs=map_kwargs,val_max=vdiff,
-            cmap=new_color_map2(), edgecolor='k',linewidth=.8)
+            cmap="OrangeBlue", edgecolor='k',linewidth=.8)
     
     if domain_type == 'all':
         latmin= 25.0
@@ -1025,7 +1015,7 @@ def make_spatial_bias_exceedance(df, column_o=None, label_o=None, column_m=None,
         #and then uses -1*val_max value for the minimum.
         ax = monet.plots.sp_scatter_bias(
             df_reg, col1=column_o+'_day', col2=column_m+'_day', map_kwargs=map_kwargs,val_max=vdiff,
-            cmap=new_color_map2(), edgecolor='k',linewidth=.8)
+            cmap="OrangeBlue", edgecolor='k',linewidth=.8)
 
         if domain_type == 'all':
             latmin= 25.0

--- a/melodies_monet/plots/surfplots.py
+++ b/melodies_monet/plots/surfplots.py
@@ -69,10 +69,8 @@ def calc_8hr_rolling_max_v1(df, col=None, window=None):
     df.index = df.time_local
     df_rolling = df.groupby("siteid")[col].rolling(window,min_periods=6,center=True, win_type="boxcar").mean().reset_index().dropna()
     # JianHe: select sites with nobs >=18, 75% completeness based on EPA
-    #df_rolling_max = df_rolling.groupby("siteid").resample("D", on="time_local").max(min_count=18).reset_index(drop=True).dropna()
     df_rolling.index = df_rolling.time_local
     df_rolling_max = df_rolling.groupby("siteid").resample("D").max(min_count=18).reset_index(drop=True).dropna()
-    #print(df_rolling_max)
     df = df.reset_index(drop=True)
     return df.merge(df_rolling_max, on=["siteid", "time_local"])
 
@@ -127,15 +125,15 @@ def new_color_map2():
         Orange and blue color map
 
     """
-    top = mpl.colormaps['Blues_r'].resampled(128)
-    bottom = mpl.colormaps['Oranges'].resampled(128)
-
-    newcolors = np.vstack((top(np.linspace(0, 1, 128)),
-                           bottom(np.linspace(0, 1, 128))))
-    newcmap = ListedColormap(newcolors, name='OrangeBlue')
-    mpl.colormaps.register(newcmap)
-
-    return newcmap
+    _cmap_name = "OrangeBlue"
+    try:
+        return(plt.get_cmap(_cmap_name))
+    except ValueError:
+        _cmap = new_color_map()
+        try:
+            return(mpl.colormaps.register(_cmap))  # mpl 3.6+
+        except AttributeError:
+            return(mpl.cm.register_cmap(cmap=_cmap))  # old method
 
 def map_projection(f):
     """Defines map projection. This needs updating to make it more generic.
@@ -313,14 +311,6 @@ def make_spatial_bias(df, df_reg=None, column_o=None, label_o=None, column_m=Non
     else:
         ylabel = '{:02d}'.format(ptile)+'th percentile '+ylabel
  
-    #Jian He, get new cmap, need use colorname below for mpl v3.6+
-    newcmap = 'OrangeBlue'
-     
-    try:
-        mpl.colormaps[newcmap]
-    except KeyError:
-        new_color_map2()
-
     if df_reg is not None:
         # JianHe: include options for percentile calculation (set in yaml file)
         if ptile is None:
@@ -332,7 +322,7 @@ def make_spatial_bias(df, df_reg=None, column_o=None, label_o=None, column_m=Non
         #and then uses -1*val_max value for the minimum.
         ax = monet.plots.sp_scatter_bias(
             df_mean, col1=column_o+'_reg', col2=column_m+'_reg', map_kwargs=map_kwargs,val_max=vdiff,
-            cmap=newcmap, edgecolor='k',linewidth=.8)
+            cmap=new_color_map2(), edgecolor='k',linewidth=.8)
     else:
         # JianHe: include options for percentile calculation (set in yaml file)
         if ptile is None:
@@ -344,7 +334,7 @@ def make_spatial_bias(df, df_reg=None, column_o=None, label_o=None, column_m=Non
         #and then uses -1*val_max value for the minimum.
         ax = monet.plots.sp_scatter_bias(
             df_mean, col1=column_o, col2=column_m, map_kwargs=map_kwargs,val_max=vdiff,
-            cmap=newcmap, edgecolor='k',linewidth=.8)
+            cmap=new_color_map2(), edgecolor='k',linewidth=.8)
     
     if domain_type == 'all':
         latmin= 25.0
@@ -1030,20 +1020,12 @@ def make_spatial_bias_exceedance(df, column_o=None, label_o=None, column_m=None,
         .reset_index(drop=True)
     )
 
-    #Jian He, get new cmap, need use colorname below for mpl v3.6+
-    newcmap = 'OrangeBlue'
-
-    try:
-        mpl.colormaps[newcmap]
-    except KeyError:
-        new_color_map2()
-
     if not df_reg.empty:
         #Specify val_max = vdiff. the sp_scatter_bias plot in MONET only uses the val_max value
         #and then uses -1*val_max value for the minimum.
         ax = monet.plots.sp_scatter_bias(
             df_reg, col1=column_o+'_day', col2=column_m+'_day', map_kwargs=map_kwargs,val_max=vdiff,
-            cmap=newcmap, edgecolor='k',linewidth=.8)
+            cmap=new_color_map2(), edgecolor='k',linewidth=.8)
 
         if domain_type == 'all':
             latmin= 25.0


### PR DESCRIPTION
With matplotlib version 3.6+, matplotlib.cm.get_cmap is deprecated. There are some incompatibility with pandas with the latest version. I have made the fixes and they are now working properly.
However, we need to pay attention on this for the future updates. I'm worried we may have the similar issues in the future. 