### PR TITLE
Restrict sites to include only those with enough data

### DIFF
--- a/docs/appendix/yaml.rst
+++ b/docs/appendix/yaml.rst
@@ -288,11 +288,11 @@ observation label is first and the model label is second
 
    * **rem_obs_by_nan_pct:** Specify as dictionary with keys 'group_var', 
      'pct_cutoff' and 'times'. If specified, removes all instances of 
-	 'group_var' where there are > 'pct_cutoff' % NaN values. For example, 
-	 with airnow sites, setting 'group_var' to 'siteid' will remove all 
-	 sites with > pct_cutoff NaN values. Setting 'times' to 'hourly' will 
-	 only look at values at the beginning of each hour. Set 'times' to ''
-	 if all times should be used.
+     'group_var' where there are > 'pct_cutoff' % NaN values. For example, 
+     with airnow sites, setting 'group_var' to 'siteid' will remove all 
+     sites with > pct_cutoff NaN values. Setting 'times' to 'hourly' will 
+     only look at values at the beginning of each hour. Set 'times' to ''
+     if all times should be used.
    * **rem_obs_nan:** If True, remove all points where model or obs variable is 
      NaN. If False, remove only points where model variable is NaN.
    * **set_axis:** If = True, use the axis constraints described in the 
@@ -362,8 +362,8 @@ observation label is first and the model label is second
 
    * **rem_obs_by_nan_pct:** Specify as dictionary with keys 'group_var', 
      'pct_cutoff' and 'times'. If specified, removes all instances of 
-	 'group_var' where there are > 'pct_cutoff' % NaN values. For example, 
-	 with airnow sites, setting 'group_var' to 'siteid' will remove all 
-	 sites with > pct_cutoff NaN values. Setting 'times' to 'hourly' will 
-	 only look at values at the beginning of each hour. Set 'times' to ''
-	 if all times should be used.
+     'group_var' where there are > 'pct_cutoff' % NaN values. For example, 
+     with airnow sites, setting 'group_var' to 'siteid' will remove all 
+     sites with > pct_cutoff NaN values. Setting 'times' to 'hourly' will 
+     only look at values at the beginning of each hour. Set 'times' to ''
+     if all times should be used.

--- a/docs/appendix/yaml.rst
+++ b/docs/appendix/yaml.rst
@@ -286,6 +286,13 @@ observation label is first and the model label is second
 
 **data_proc:** This section stores all of the data processing information.
 
+   * **rem_obs_by_nan_pct:** Specify as dictionary with keys 'group_var', 
+     'pct_cutoff' and 'times'. If specified, removes all instances of 
+	 'group_var' where there are > 'pct_cutoff' % NaN values. For example, 
+	 with airnow sites, setting 'group_var' to 'siteid' will remove all 
+	 sites with > pct_cutoff NaN values. Setting 'times' to 'hourly' will 
+	 only look at values at the beginning of each hour. Set 'times' to ''
+	 if all times should be used.
    * **rem_obs_nan:** If True, remove all points where model or obs variable is 
      NaN. If False, remove only points where model variable is NaN.
    * **set_axis:** If = True, use the axis constraints described in the 
@@ -350,3 +357,13 @@ where domain_type is equal to domain_name.
 **data:** This a list of model / observation pairs to be plotted where the 
 observation label is first and the model label is second 
 (e.g., ['airnow_cmaq_expt', 'airnow_rrfs_13km', 'airnow_wrfchem_v4.2'])
+
+**data_proc:** This section stores all of the data processing information.
+
+   * **rem_obs_by_nan_pct:** Specify as dictionary with keys 'group_var', 
+     'pct_cutoff' and 'times'. If specified, removes all instances of 
+	 'group_var' where there are > 'pct_cutoff' % NaN values. For example, 
+	 with airnow sites, setting 'group_var' to 'siteid' will remove all 
+	 sites with > pct_cutoff NaN values. Setting 'times' to 'hourly' will 
+	 only look at values at the beginning of each hour. Set 'times' to ''
+	 if all times should be used.

--- a/docs/appendix/yaml.rst
+++ b/docs/appendix/yaml.rst
@@ -292,7 +292,8 @@ observation label is first and the model label is second
      with airnow sites, setting 'group_var' to 'siteid' will remove all 
      sites with > pct_cutoff NaN values. Setting 'times' to 'hourly' will 
      only look at values at the beginning of each hour. Set 'times' to ''
-     if all times should be used.
+     if all times should be used. This calculation occurs 
+     over the entire analysis window and prior to calculating the regulatory metrics.
    * **rem_obs_nan:** If True, remove all points where model or obs variable is 
      NaN. If False, remove only points where model variable is NaN.
    * **set_axis:** If = True, use the axis constraints described in the 

--- a/docs/appendix/yaml.rst
+++ b/docs/appendix/yaml.rst
@@ -367,4 +367,5 @@ observation label is first and the model label is second
      with airnow sites, setting 'group_var' to 'siteid' will remove all 
      sites with > pct_cutoff NaN values. Setting 'times' to 'hourly' will 
      only look at values at the beginning of each hour. Set 'times' to ''
-     if all times should be used.
+     if all times should be used. This calculation occurs 
+     over the entire analysis window and prior to calculating the regulatory metrics.

--- a/examples/yaml/control_cmaq-rrfs_surface-all-short_test_jupyter.yaml
+++ b/examples/yaml/control_cmaq-rrfs_surface-all-short_test_jupyter.yaml
@@ -156,6 +156,7 @@ plots:
     domain_name: ['CONUS','R1'] #List of domain names. If domain_type = all domain_name is used in plot title.
     data: ['airnow_rrfs_r131v1','airnow_cmaq_expt','airnow_cmaq_oper'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
     data_proc:
+      #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       ts_select_time: 'time_local' #Time used for avg and plotting: Options: 'time' for UTC or 'time_local'
       ts_avg_window: 'H' # Options: None for no averaging or list pandas resample rule (e.g., 'H', 'D')
@@ -172,6 +173,7 @@ plots:
     domain_name: ['CONUS'] #List of domain names. If domain_type = all domain_name is used in plot title.
     data: ['airnow_rrfs_r131v1','airnow_cmaq_expt','airnow_cmaq_oper'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
     data_proc:
+      #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       set_axis: True #If select True, add ty_scale for each variable in obs.
   plot_grp3:
@@ -185,6 +187,7 @@ plots:
     domain_name: ['CONUS'] #List of domain names. If domain_type = all domain_name is used in plot title.
     data: ['airnow_rrfs_r131v1','airnow_cmaq_expt','airnow_cmaq_oper'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
     data_proc:
+      #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       set_axis: True #If select True, add vdiff_plot for each variable in obs.
   plot_grp4:
@@ -198,6 +201,7 @@ plots:
     domain_name: ['CONUS'] #List of domain names. If domain_type = all domain_name is used in plot title.
     data: ['airnow_rrfs_r131v1','airnow_cmaq_expt','airnow_cmaq_oper'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
     data_proc:
+      #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       set_axis: True #If select True, add vmin_plot and vmax_plot for each variable in obs.
   plot_grp5:
@@ -210,6 +214,7 @@ plots:
     domain_name: ['CONUS'] #List of domain names. If domain_type = all domain_name is used in plot title.
     data: ['airnow_rrfs_r131v1','airnow_cmaq_expt','airnow_cmaq_oper'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
     data_proc:
+      #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       set_axis: False #If select True, add vmin_plot and vmax_plot for each variable in obs.
 stats:
@@ -228,4 +233,5 @@ stats:
   domain_type: ['all'] #List of domain types: 'all' or any domain in obs file. (e.g., airnow: epa_region, state_name, siteid, etc.) 
   domain_name: ['CONUS'] #List of domain names. If domain_type = all domain_name is used in plot title.
   data: ['airnow_rrfs_r131v1','airnow_cmaq_expt','airnow_cmaq_oper'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
-
+  #data_proc:
+      #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values

--- a/examples/yaml/control_cmaq-rrfs_surface-all.yaml
+++ b/examples/yaml/control_cmaq-rrfs_surface-all.yaml
@@ -156,6 +156,7 @@ plots:
     domain_name: ['CONUS','R1','R2','R3','R4','R5','R6','R7','R8','R9','R10'] #List of domain names. If domain_type = all domain_name is used in plot title.
     data: ['airnow_rrfs_r131v1','airnow_cmaq_expt','airnow_cmaq_oper'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
     data_proc:
+      #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       ts_select_time: 'time_local' #Time used for avg and plotting: Options: 'time' for UTC or 'time_local'
       ts_avg_window: 'H' # Options: None for no averaging or list pandas resample rule (e.g., 'H', 'D')
@@ -172,6 +173,7 @@ plots:
     domain_name: ['CONUS','R1','R2','R3','R4','R5','R6','R7','R8','R9','R10'] #List of domain names. If domain_type = all domain_name is used in plot title.
     data: ['airnow_rrfs_r131v1','airnow_cmaq_expt','airnow_cmaq_oper'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
     data_proc:
+      #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       set_axis: True #If select True, add ty_scale for each variable in obs.
   plot_grp3:
@@ -198,6 +200,7 @@ plots:
     domain_name: ['CONUS'] #List of domain names. If domain_type = all domain_name is used in plot title.
     data: ['airnow_rrfs_r131v1','airnow_cmaq_expt','airnow_cmaq_oper'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
     data_proc:
+      #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       set_axis: True #If select True, add vmin_plot and vmax_plot for each variable in obs.
   plot_grp5:
@@ -210,6 +213,7 @@ plots:
     domain_name: ['CONUS','R1','R2','R3','R4','R5','R6','R7','R8','R9','R10'] #List of domain names. If domain_type = all domain_name is used in plot title.
     data: ['airnow_rrfs_r131v1','airnow_cmaq_expt','airnow_cmaq_oper'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
     data_proc:
+      #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       set_axis: False #If select True, add vmin_plot and vmax_plot for each variable in obs.
 stats:
@@ -228,4 +232,5 @@ stats:
   domain_type: ['all'] #List of domain types: 'all' or any domain in obs file. (e.g., airnow: epa_region, state_name, siteid, etc.) 
   domain_name: ['CONUS'] #List of domain names. If domain_type = all domain_name is used in plot title.
   data: ['airnow_rrfs_r131v1','airnow_cmaq_expt','airnow_cmaq_oper'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
-
+  #data_proc:
+      #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values

--- a/examples/yaml/control_cmaq-rrfs_surface.yaml
+++ b/examples/yaml/control_cmaq-rrfs_surface.yaml
@@ -194,6 +194,7 @@ plots:
     domain_name: ['CONUS','R1','R2','R3','R4','R5','R6','R7','R8','R9','R10'] #List of domain names. If domain_type = all domain_name is used in plot title.
     data: ['airnow_rrfs_r131v1_all','airnow_rrfs_r131v1_wopc','airnow_rrfs_r131v1_pm25','airnow_cmaq_expt','airnow_cmaq_oper'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
     data_proc:
+      #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       ts_select_time: 'time_local' #Time used for avg and plotting: Options: 'time' for UTC or 'time_local'
       ts_avg_window: 'H' # Options: None for no averaging or list pandas resample rule (e.g., 'H', 'D')
@@ -210,6 +211,7 @@ plots:
     domain_name: ['CONUS','R1','R2','R3','R4','R5','R6','R7','R8','R9','R10'] #List of domain names. If domain_type = all domain_name is used in plot title.
     data: ['airnow_rrfs_r131v1_all','airnow_rrfs_r131v1_wopc','airnow_rrfs_r131v1_pm25','airnow_cmaq_expt','airnow_cmaq_oper'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
     data_proc:
+      #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       set_axis: True #If select True, add ty_scale for each variable in obs.
   plot_grp3:
@@ -223,6 +225,7 @@ plots:
     domain_name: ['CONUS'] #List of domain names. If domain_type = all domain_name is used in plot title.
     data: ['airnow_rrfs_r131v1_all','airnow_rrfs_r131v1_wopc','airnow_rrfs_r131v1_pm25','airnow_cmaq_expt','airnow_cmaq_oper'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
     data_proc:
+      #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       set_axis: True #If select True, add vdiff_plot for each variable in obs.
   plot_grp4:
@@ -236,6 +239,7 @@ plots:
     domain_name: ['CONUS'] #List of domain names. If domain_type = all domain_name is used in plot title.
     data: ['airnow_rrfs_r131v1_all','airnow_rrfs_r131v1_wopc','airnow_rrfs_r131v1_pm25','airnow_cmaq_expt','airnow_cmaq_oper'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
     data_proc:
+      #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       set_axis: True #If select True, add vmin_plot and vmax_plot for each variable in obs.
   plot_grp5:
@@ -248,6 +252,7 @@ plots:
     domain_name: ['CONUS','R1','R2','R3','R4','R5','R6','R7','R8','R9','R10'] #List of domain names. If domain_type = all domain_name is used in plot title.
     data: ['airnow_rrfs_r131v1_all','airnow_rrfs_r131v1_wopc','airnow_rrfs_r131v1_pm25','airnow_cmaq_expt','airnow_cmaq_oper'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
     data_proc:
+      #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       set_axis: False #If select True, add vmin_plot and vmax_plot for each variable in obs.
 stats:
@@ -266,4 +271,5 @@ stats:
   domain_type: ['all'] #List of domain types: 'all' or any domain in obs file. (e.g., airnow: epa_region, state_name, siteid, etc.) 
   domain_name: ['CONUS'] #List of domain names. If domain_type = all domain_name is used in plot title.
   data: ['airnow_rrfs_r131v1_all','airnow_rrfs_r131v1_wopc','airnow_rrfs_r131v1_pm25','airnow_cmaq_expt','airnow_cmaq_oper'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
-
+  #data_proc:
+      #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values

--- a/examples/yaml/control_cmaq.yaml
+++ b/examples/yaml/control_cmaq.yaml
@@ -148,6 +148,7 @@ plots:
     domain_name: ['CONUS'] #List of domain names. If domain_type = all domain_name is used in plot title.
     data: ['airnow_cmaq_expt','airnow_rrfs_13km','airnow_wrfchem_v4.2'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
     data_proc:
+      #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       ts_select_time: 'time_local' #Time used for avg and plotting: Options: 'time' for UTC or 'time_local'
       ts_avg_window: 'H' # Options: None for no averaging or list pandas resample rule (e.g., 'H', 'D')
@@ -165,6 +166,7 @@ plots:
     domain_name: ['CONUS'] #List of domain names. If domain_type = all domain_name is used in plot title.
     data: ['airnow_cmaq_expt','airnow_rrfs_13km','airnow_wrfchem_v4.2'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
     data_proc:
+      #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       set_axis: True #If select True, add ty_scale for each variable in obs.
   plot_grp3:
@@ -178,6 +180,7 @@ plots:
     domain_name: ['CONUS'] #List of domain names. If domain_type = all domain_name is used in plot title.
     data: ['airnow_cmaq_expt','airnow_rrfs_13km','airnow_wrfchem_v4.2'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
     data_proc:
+      #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       set_axis: True #If select True, add vdiff_plot for each variable in obs.
   plot_grp4:
@@ -191,6 +194,7 @@ plots:
     domain_name: ['CONUS'] #List of domain names. If domain_type = all domain_name is used in plot title.
     data: ['airnow_cmaq_expt','airnow_rrfs_13km','airnow_wrfchem_v4.2'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
     data_proc:
+      #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       set_axis: True #If select True, add vmin_plot and vmax_plot for each variable in obs.
   plot_grp5:
@@ -203,6 +207,7 @@ plots:
     domain_name: ['CONUS'] #List of domain names. If domain_type = all domain_name is used in plot title.
     data: ['airnow_cmaq_expt','airnow_rrfs_13km','airnow_wrfchem_v4.2'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
     data_proc:
+      #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       set_axis: False #If select True, add vmin_plot and vmax_plot for each variable in obs.
 stats:
@@ -221,4 +226,5 @@ stats:
   domain_type: ['all'] #List of domain types: 'all' or any domain in obs file. (e.g., airnow: epa_region, state_name, siteid, etc.) 
   domain_name: ['CONUS'] #List of domain names. If domain_type = all domain_name is used in plot title.
   data: ['airnow_cmaq_expt','airnow_rrfs_13km','airnow_wrfchem_v4.2'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
-
+  #data_proc:
+      #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values

--- a/examples/yaml/control_rrfs_cmaq_airnow_norm.yaml
+++ b/examples/yaml/control_rrfs_cmaq_airnow_norm.yaml
@@ -160,6 +160,7 @@ plots:
     domain_name: ['CONUS','R1','R2','R3','R4','R5','R6','R7','R8','R9','R10'] #List of domain names. If domain_type = all domain_name is used in plot title.
     data: ['airnow_cmaq_oper','airnow_cmaq_nacc','airnow_rrfs_v150_a'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
     data_proc:
+      #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       ts_select_time: 'time_local' #Time used for avg and plotting: Options: 'time' for UTC or 'time_local'
       ts_avg_window: 'H' # Options: None for no averaging or list pandas resample rule (e.g., 'H', 'D')
@@ -176,6 +177,7 @@ plots:
     domain_name: ['CONUS','R1','R2','R3','R4','R5','R6','R7','R8','R9','R10'] #List of domain names. If domain_type = all domain_name is used in plot title.
     data: ['airnow_cmaq_oper','airnow_cmaq_nacc','airnow_rrfs_v150_a'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
     data_proc:
+      #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       set_axis: True #If select True, add ty_scale for each variable in obs.
   plot_grp3:
@@ -189,6 +191,7 @@ plots:
     domain_name: ['CONUS'] #List of domain names. If domain_type = all domain_name is used in plot title.
     data: ['airnow_cmaq_oper','airnow_cmaq_nacc','airnow_rrfs_v150_a'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
     data_proc:
+      #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       set_axis: True #If select True, add vdiff_plot for each variable in obs.
   plot_grp4:
@@ -202,6 +205,7 @@ plots:
     domain_name: ['CONUS'] #List of domain names. If domain_type = all domain_name is used in plot title.
     data: ['airnow_cmaq_oper','airnow_cmaq_nacc','airnow_rrfs_v150_a'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
     data_proc:
+      #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       set_axis: True #If select True, add vmin_plot and vmax_plot for each variable in obs.
   plot_grp5:
@@ -214,6 +218,7 @@ plots:
     domain_name: ['CONUS','R1','R2','R3','R4','R5','R6','R7','R8','R9','R10'] #List of domain names. If domain_type = all domain_name is used in plot title.
     data: ['airnow_cmaq_oper','airnow_cmaq_nacc','airnow_rrfs_v150_a'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
     data_proc:
+      #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       set_axis: False #If select True, add vmin_plot and vmax_plot for each variable in obs.
   plot_grp6:
@@ -227,6 +232,7 @@ plots:
     domain_name: ['CONUS'] #List of domain names. If domain_type = all domain_name is used in plot title.
     data: ['airnow_cmaq_oper','airnow_cmaq_nacc','airnow_rrfs_v150_a'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
     data_proc:
+      #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       set_axis: True #If select True, add vdiff_plot for each variable in obs.
 stats:
@@ -245,3 +251,5 @@ stats:
   domain_type: ['all','epa_region','epa_region','epa_region','epa_region','epa_region','epa_region','epa_region','epa_region','epa_region','epa_region'] #List of domain types: 'all' or any domain in obs file. (e.g., airnow: epa_region, state_name, siteid, etc.)
   domain_name: ['CONUS','R1','R2','R3','R4','R5','R6','R7','R8','R9','R10'] #List of domain names. If domain_type = all domain_name is used in plot title.
   data: ['airnow_cmaq_oper','airnow_cmaq_nacc','airnow_rrfs_v150_a'] # make this a list of pairs in obs_model where the obs is the obs labeland model is the model_label
+  #data_proc:
+      #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values

--- a/examples/yaml/control_rrfs_cmaq_airnow_reg.yaml
+++ b/examples/yaml/control_rrfs_cmaq_airnow_reg.yaml
@@ -160,6 +160,7 @@ plots:
     domain_name: ['CONUS','R1','R2','R3','R4','R5','R6','R7','R8','R9','R10'] #List of domain names. If domain_type = all domain_name is used in plot title.
     data: ['airnow_cmaq_oper','airnow_cmaq_nacc','airnow_rrfs_v150_a'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
     data_proc:
+      #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       ts_select_time: 'time_local' #Time used for avg and plotting: Options: 'time' for UTC or 'time_local'
       ts_avg_window: 'D' # Options: None for no averaging or list pandas resample rule (e.g., 'H', 'D')
@@ -176,6 +177,7 @@ plots:
     domain_name: ['CONUS','R1','R2','R3','R4','R5','R6','R7','R8','R9','R10'] #List of domain names. If domain_type = all domain_name is used in plot title.
     data: ['airnow_cmaq_oper','airnow_cmaq_nacc','airnow_rrfs_v150_a'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
     data_proc:
+      #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       set_axis: True #If select True, add ty_scale for each variable in obs.
   plot_grp3:
@@ -189,6 +191,7 @@ plots:
     domain_name: ['CONUS'] #List of domain names. If domain_type = all domain_name is used in plot title.
     data: ['airnow_cmaq_oper','airnow_cmaq_nacc','airnow_rrfs_v150_a'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
     data_proc:
+      #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       set_axis: True #If select True, add vdiff_plot for each variable in obs.
   plot_grp4:
@@ -202,6 +205,7 @@ plots:
     domain_name: ['CONUS'] #List of domain names. If domain_type = all domain_name is used in plot title.
     data: ['airnow_cmaq_oper','airnow_cmaq_nacc','airnow_rrfs_v150_a'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
     data_proc:
+      #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       set_axis: True #If select True, add vmin_plot and vmax_plot for each variable in obs.
   plot_grp5:
@@ -214,6 +218,7 @@ plots:
     domain_name: ['CONUS','R1','R2','R3','R4','R5','R6','R7','R8','R9','R10'] #List of domain names. If domain_type = all domain_name is used in plot title.
     data: ['airnow_cmaq_oper','airnow_cmaq_nacc','airnow_rrfs_v150_a'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
     data_proc:
+      #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       set_axis: False #If select True, add vmin_plot and vmax_plot for each variable in obs.
   plot_grp6:
@@ -227,6 +232,7 @@ plots:
     domain_name: ['CONUS'] #List of domain names. If domain_type = all domain_name is used in plot title.
     data: ['airnow_cmaq_oper','airnow_cmaq_nacc','airnow_rrfs_v150_a'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
     data_proc:
+      #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       set_axis: True #If select True, add vdiff_plot for each variable in obs.
 stats:
@@ -245,3 +251,5 @@ stats:
   domain_type: ['all','epa_region','epa_region','epa_region','epa_region','epa_region','epa_region','epa_region','epa_region','epa_region','epa_region'] #List of domain types: 'all' or any domain in obs file. (e.g., airnow: epa_region, state_name, siteid, etc.)
   domain_name: ['CONUS','R1','R2','R3','R4','R5','R6','R7','R8','R9','R10'] #List of domain names. If domain_type = all domain_name is used in plot title.
   data: ['airnow_cmaq_oper','airnow_cmaq_nacc','airnow_rrfs_v150_a'] # make this a list of pairs in obs_model where the obs is the obs labeland model is the model_label
+  #data_proc:
+      #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values

--- a/examples/yaml/control_wrfchem.yaml
+++ b/examples/yaml/control_wrfchem.yaml
@@ -110,6 +110,7 @@ plots:
     domain_name: ['CONUS'] #List of domain names. If domain_type = all domain_name is used in plot title.
     data: ['airnow_wrfchem_v4.2'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
     data_proc:
+      #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       ts_select_time: 'time_local' #Time used for avg and plotting: Options: 'time' for UTC or 'time_local'
       ts_avg_window: 'H' # Options: None for no averaging or list pandas resample rule (e.g., 'H', 'D')
@@ -127,6 +128,7 @@ plots:
     domain_name: ['CONUS'] #List of domain names. If domain_type = all domain_name is used in plot title.
     data: ['airnow_wrfchem_v4.2'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
     data_proc:
+      #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       set_axis: True #If select True, add ty_scale for each variable in obs.
   plot_grp3:
@@ -140,6 +142,7 @@ plots:
     domain_name: ['CONUS'] #List of domain names. If domain_type = all domain_name is used in plot title.
     data: ['airnow_wrfchem_v4.2'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
     data_proc:
+      #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       set_axis: True #If select True, add vdiff_plot for each variable in obs.
   plot_grp4:
@@ -153,6 +156,7 @@ plots:
     domain_name: ['CONUS'] #List of domain names. If domain_type = all domain_name is used in plot title.
     data: ['airnow_wrfchem_v4.2'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
     data_proc:
+      #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       set_axis: True #If select True, add vmin_plot and vmax_plot for each variable in obs.
   plot_grp5:
@@ -165,6 +169,7 @@ plots:
     domain_name: ['CONUS'] #List of domain names. If domain_type = all domain_name is used in plot title.
     data: ['airnow_wrfchem_v4.2'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
     data_proc:
+      #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       set_axis: False #If select True, add vmin_plot and vmax_plot for each variable in obs.
 stats:
@@ -183,4 +188,6 @@ stats:
   domain_type: ['all'] #List of domain types: 'all' or any domain in obs file. (e.g., airnow: epa_region, state_name, siteid, etc.) 
   domain_name: ['CONUS'] #List of domain names. If domain_type = all domain_name is used in plot title.
   data: ['airnow_wrfchem_v4.2'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
+  #data_proc:
+      #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values
 

--- a/melodies_monet/driver.py
+++ b/melodies_monet/driver.py
@@ -865,7 +865,30 @@ class analysis:
                         # Query selected points if applicable
                         if domain_type != 'all':
                             pairdf_all.query(domain_type + ' == ' + '"' + domain_name + '"', inplace=True)
+                        
+                        # Drop sites with greater than X percent NAN values
+                        if 'rem_obs_by_nan_pct' in grp_dict['data_proc']:
+                            grp_var = grp_dict['data_proc']['rem_obs_by_nan_pct']['group_var']
+                            pct_cutoff = grp_dict['data_proc']['rem_obs_by_nan_pct']['pct_cutoff']
+                            
+                            if grp_dict['data_proc']['rem_obs_by_nan_pct']['times'] == 'hourly':
+                                # Select only hours at the hour
+                                hourly_pairdf_all = pairdf_all.reset_index().loc[pairdf_all.reset_index()['time'].dt.minute==0,:]
+                                
+                                # calculate total obs count, obs count with nan removed, and nan percent for each group
+                                grp_fullcount = hourly_pairdf_all[[grp_var,obsvar]].groupby(grp_var).size().rename({0:obsvar})
+                                grp_nonan_count = hourly_pairdf_all[[grp_var,obsvar]].groupby(grp_var).count() # counts only non NA values    
+                            else: 
+                                # calculate total obs count, obs count with nan removed, and nan percent for each group
+                                grp_fullcount = pairdf_all[[grp_var,obsvar]].groupby(grp_var).size().rename({0:obsvar})
+                                grp_nonan_count = pairdf_all[[grp_var,obsvar]].groupby(grp_var).count() # counts only non NA values  
+                                
+                            grp_pct_nan = 100 - grp_nonan_count.div(grp_fullcount,axis=0)*100
 
+                            # make list of sites meeting condition and select paired data by this by this
+                            grp_select = grp_pct_nan.query(obsvar + ' < ' + str(pct_cutoff)).reset_index()
+                            pairdf_all = pairdf_all.loc[pairdf_all[grp_var].isin(grp_select[grp_var].values)]
+                        
                         # Drop NaNs
                         if grp_dict['data_proc']['rem_obs_nan'] == True:
                             # I removed drop=True in reset_index in order to keep 'time' as a column.
@@ -1306,7 +1329,31 @@ class analysis:
                         # Query selected points if applicable
                         if domain_type != 'all':
                             pairdf_all.query(domain_type + ' == ' + '"' + domain_name + '"', inplace=True)
+                        
+                        # Drop sites with greater than X percent NAN values
+                        if 'data_proc' in stat_dict:
+                            if 'rem_obs_by_nan_pct' in stat_dict['data_proc']:
+                                grp_var = stat_dict['data_proc']['rem_obs_by_nan_pct']['group_var']
+                                pct_cutoff = stat_dict['data_proc']['rem_obs_by_nan_pct']['pct_cutoff']
 
+                                if stat_dict['data_proc']['rem_obs_by_nan_pct']['times'] == 'hourly':
+                                    # Select only hours at the hour
+                                    hourly_pairdf_all = pairdf_all.reset_index().loc[pairdf_all.reset_index()['time'].dt.minute==0,:]
+                                    
+                                    # calculate total obs count, obs count with nan removed, and nan percent for each group
+                                    grp_fullcount = hourly_pairdf_all[[grp_var,obsvar]].groupby(grp_var).size().rename({0:obsvar})
+                                    grp_nonan_count = hourly_pairdf_all[[grp_var,obsvar]].groupby(grp_var).count() # counts only non NA values    
+                                else: 
+                                    # calculate total obs count, obs count with nan removed, and nan percent for each group
+                                    grp_fullcount = pairdf_all[[grp_var,obsvar]].groupby(grp_var).size().rename({0:obsvar})
+                                    grp_nonan_count = pairdf_all[[grp_var,obsvar]].groupby(grp_var).count() # counts only non NA values  
+                                
+                                grp_pct_nan = 100 - grp_nonan_count.div(grp_fullcount,axis=0)*100
+                                
+                                # make list of sites meeting condition and select paired data by this by this
+                                grp_select = grp_pct_nan.query(obsvar + ' < ' + str(pct_cutoff)).reset_index()
+                                pairdf_all = pairdf_all.loc[pairdf_all[grp_var].isin(grp_select[grp_var].values)]
+                        
                         # Drop NaNs for model and observations in all cases.
                         pairdf = pairdf_all.reset_index().dropna(subset=[modvar, obsvar])
 


### PR DESCRIPTION
Pull request to address issue #150.

This adds a yaml option to restrict observations based on the percentage of NaN values. The yaml option is formated as follows and lives under the data_proc option in the plotting and statistics groups:
`rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'}`

Originally this was intended to restrict by the percentage of data available for a site in airnow over the analysis time period. To make this more configurable I've made it so that the yaml option is configurable such that the user can remove by variables other that siteid in observation data. For example if the user wanted to remove any state where the NaN percentage is too great, the value for 'group_var' could be changed to 'state_name'.

In the yaml option 'pct_cutoff' is the maximum allowable percent of NaN values. The value for 'times' controls when the observations should be examined for NaN values. When 'times' is set to 'hourly', 'group_var' will only be examined for percentage NaN values at the top of the hour. When it is set to anything else it will look at all time values available. Airnow data seems to generally only be available on the hour but has NaN values between the hour so without restricting to on the hour airnow data has a much larger percentage NaN values. 