### PR TITLE
Add eval method for setting projection

### DIFF
--- a/docs/appendix/yaml.rst
+++ b/docs/appendix/yaml.rst
@@ -129,8 +129,32 @@ For example, ::
       PM25_TOT: 'PM2.5'
       O3: 'OZONE'
     
-**projection:** Not used currently in the code. This is under development and 
-likely to be moved to the "plots" section
+**projection:** In order to use the default projection for each model as defined 
+in the map_projection function in melodies_monet/plots/surfplots.py either remove 
+the projection setting or set to `~` or `null`. If the model does not have a 
+default projection defined, `ccrs.PlateCarree()` will be used.
+
+If you would like to override the default projection for a model, you have three 
+options:
+
+1) Specify one of the model preset options (e.g., to use the default RAQMS 
+projection for another model write projection: 'model:raqms'). Note: For certain 
+models, central longitude and/or central latitude are required, so check the 
+map_projection function in melodies_monet/plots/surfplots.py and confirm the 
+correct attributes are applied for your given model dataset.
+
+2) Add a proj4 string or dictionary for cartopy.crs.Projection. Note: If a proj4 
+string or dictionary is used, it must completely define an instance of 
+cartopy.crs.Projection. For example, converting ccrs.PlateCarre() to a proj4 
+string results in {'proj': 'eqc', 'lat_ts': 0, 'lat_0': 0, 'lon_0': 0, 'x_0': 0, 
+'y_0': 0, 'ellps': 'WGS84', 'to_meter': 111319.490793274, 'no_defs': None, 
+'type': 'crs'}, but this is not able to completely define an instance of 
+cartopy.crs.Projection due to a the missing .boundary attribute. 
+A string such as 'EPSG:4326' will work.(e.g., projection: 'EPSG:4326').
+
+3) Add a string with a cartopy.crs command to be evaluated when defining the 
+projection used. This string must start with 'ccrs.'. For example, 
+projection: 'ccrs.PlateCarre()'.
 
 **plot_kwargs:** This is optional. If you do not provide this, MELODIES MONET 
 will use a default list of colors. Add a dictionary of plotting characteristics

--- a/melodies_monet/driver.py
+++ b/melodies_monet/driver.py
@@ -680,6 +680,9 @@ class analysis:
                 if proj_in is not None:
                     if isinstance(proj_in, str) and proj_in.startswith("model:"):
                         m.proj = proj_in
+                    elif isinstance(proj_in, str) and proj_in.startswith("ccrs."):
+                        import cartopy.crs as ccrs
+                        m.proj = eval(proj_in)
                     else:
                         import cartopy.crs as ccrs
 


### PR DESCRIPTION
Adds the ability to set projection in the control file with a string that will be evaluated using eval(). If the string begins with 'ccrs.', the eval method is triggered on the string.  For example `projection: ccrs.PlateCarre()` is the equivalent of m.proj = ccrs.PlateCarre().

