### PR TITLE
Add ability to read aircraft obs from .csv file

### DIFF
--- a/melodies_monet/driver.py
+++ b/melodies_monet/driver.py
@@ -120,6 +120,7 @@ class observation:
         self.data_proc = None
         self.variable_dict = None
         self.resample = None
+        self.time_var = None
 
     def __repr__(self):
         return (
@@ -170,6 +171,10 @@ class observation:
             elif extension in ['.ict', '.icartt']:
                 assert len(files) == 1, "monetio.icartt.add_data can only read one file"
                 self.obj = mio.icartt.add_data(files[0])
+            elif extension in ['.csv']:
+                from .util.read_util import read_aircraft_obs_csv
+                assert len(files) == 1, "MELODIES-MONET can only read one csv file"
+                self.obj = read_aircraft_obs_csv(filename=files[0],time_var=self.time_var)
             else:
                 raise ValueError(f'extension {extension!r} currently unsupported')
         except Exception as e:
@@ -778,6 +783,8 @@ class analysis:
                     o.variable_dict = self.control_dict['obs'][obs]['variables']
                 if 'resample' in self.control_dict['obs'][obs].keys():
                     o.resample = self.control_dict['obs'][obs]['resample']
+                if 'time_var' in self.control_dict['obs'][obs].keys():
+                    o.time_var = self.control_dict['obs'][obs]['time_var']
                 o.open_obs(time_interval=time_interval)
                 self.obs[o.label] = o
 

--- a/melodies_monet/util/read_util.py
+++ b/melodies_monet/util/read_util.py
@@ -212,3 +212,4 @@ def read_aircraft_obs_csv(filename,time_var=None):
     
     return xr.Dataset.from_dataframe(df)
     
+    

--- a/melodies_monet/util/read_util.py
+++ b/melodies_monet/util/read_util.py
@@ -182,3 +182,33 @@ def xarray_to_class(class_type,group_ds):
         class_dict[group]=c
 
     return class_dict
+
+def read_aircraft_obs_csv(filename,time_var=None):
+    """Function to read .csv formatted aircraft observations.
+
+    Parameters
+    ----------
+    filename : str 
+        Filename of .csv file to be read
+    time_var : optional
+        The variable in the dataset that should be converted to 
+        datetime format, renamed to `time` and set as a dimension.
+        
+    Returns
+    -------
+    ds_out : xarray.Dataset
+        Xarray dataset containing information from .csv file
+
+    """
+    import xarray as xr
+    import pandas as pd
+    
+    df = pd.read_csv(filename)
+    if time_var is not None:
+        df.rename(columns={time_var:'time'},inplace=True)
+        df['time']  = pd.to_datetime(df['time'])
+        
+    df.set_index('time',inplace=True)
+    
+    return xr.Dataset.from_dataframe(df)
+    

--- a/melodies_monet/util/read_util.py
+++ b/melodies_monet/util/read_util.py
@@ -211,5 +211,3 @@ def read_aircraft_obs_csv(filename,time_var=None):
     df.set_index('time',inplace=True)
     
     return xr.Dataset.from_dataframe(df)
-    
-    


### PR DESCRIPTION
This adds the ability to read aircraft obs from a .csv file. 

To accommodate different column names for the 'time' dimension and coordinates, I added the ability to set the column that should be used as time in the control file. This is set under the observation name as shown in the example below:

```
obs:
  sabre: # obs label
    filename: '/wrk/charkins/melodies_monet/aircraft/add_csv_read/SABRE-Merge_20230305_20230306_1719.csv'
    obs_type: aircraft
    time_var: TIME_START
    resample: '600S' 
```