### PR TITLE
Remove extraneous options in mask_and_scale

### DIFF
--- a/melodies_monet/driver.py
+++ b/melodies_monet/driver.py
@@ -243,11 +243,6 @@ class observation:
                             self.obj[v].data += scale
                         elif d['unit_scale_method'] == '-':
                             self.obj[v].data += -1 * scale
-                    if 'obs_unit' in d:
-                        unitin = d['obs_unit']
-                        if unitin in {'ppmv', 'ppm'}:
-                            scale = 1000. # convert to ppb
-                            self.obj[v].data *= scale
 
     def obs_to_df(self):
         """Convert and reformat observation object (:attr:`obj`) to dataframe.
@@ -432,11 +427,6 @@ class model:
                             self.obj[v].data += scale
                         elif d['unit_scale_method'] == '-':
                             self.obj[v].data += -1 * scale
-                    if 'om2oc_factor' in d:
-                        print('Convert OM to OC here using factor ',d['om2oc_factor'],self.obj[v].data)
-                        scale = d['om2oc_factor']
-                        self.obj[v].data = self.obj[v].data/scale
-
 
 class analysis:
     """The analysis class.


### PR DESCRIPTION
This commit removes extraneous scaling options in the mask_and_scale() functions of the obs and model classes in driver.py. The removed scaling options can be accomplished with `unit_scale` and `unit_scale_method`. The options were not included in the documentation and so do not need to be removed from there.