### PR TITLE
Update resample_stratify function in tools.py to work with new stratify version

### DIFF
--- a/melodies_monet/util/tools.py
+++ b/melodies_monet/util/tools.py
@@ -276,7 +276,7 @@ def resample_stratify(da, levels, vertical, axis=1,interpolation='linear',extrap
     import stratify
     import xarray as xr
 
-    result = stratify.interpolate(levels, vertical.chunk(), da.chunk(), axis=axis,
+    result = stratify.interpolate(levels, vertical.chunk().data, da.chunk().data, axis=axis,
                                  interpolation = interpolation,extrapolation = extrapolation)
     dims = da.dims
     out = xr.DataArray(result, dims=dims)


### PR DESCRIPTION
A new version of the stratify function was released to conda recently. This caused `melodies_monet.util.tools.resample_stratify()` to break due to the way it passes data to `stratify.interpolate()`. The error was 'DataArray' object has no attribute 'rechunk'. 

The new version of stratify assumes that the data passed is either as a `dask.array` or as a `numpy.ndarray`. Passing the data contained in the DataArray, rather than the DataArray itself fixes the issue.

Thanks to @quaz115 for bringing this error to my attention. 