### PR TITLE
Update in driver.py to make ts_avg_window Optional, works for both ts_avg_window specified in yaml or not

### DIFF
--- a/melodies_monet/driver.py
+++ b/melodies_monet/driver.py
@@ -1042,7 +1042,11 @@ class analysis:
                                 vmax = None
                             # Select time to use as index.
                             pairdf = pairdf.set_index(grp_dict['data_proc']['ts_select_time'])
-                            a_w = grp_dict['data_proc']['ts_avg_window']
+                            # Specify ts_avg_window if noted in yaml file. #qzr++
+                            if 'ts_avg_window' in grp_dict['data_proc'].keys():
+                                a_w = grp_dict['data_proc']['ts_avg_window']
+                            else:
+                                a_w = None  #qzr++ ends
                             if p_index == 0:
                                 # First plot the observations.
                                 ax = splots.make_timeseries(


### PR DESCRIPTION
Earlier ts_avg_window was needed in 'timeseries' plot type (e.g., 'H' or 'D' for hourly or daily averages), and didn't work with None specified to ts_avg_window.

This would be more useful for aircraft evaluations (looking at timeseries with altitude profile data)