### PR TITLE
Add ability to pair model with mobile drive data and single ground site data

### DIFF
--- a/examples/yaml/control_hrrr-smoke_mobile.yaml
+++ b/examples/yaml/control_hrrr-smoke_mobile.yaml
@@ -1,0 +1,126 @@
+# General Description:  
+# Any key that is specific for a plot type will begin with ts for timeseries, ty for taylor
+# Opt: Specifying the variable or variable group is optional
+# For now all plots except time series average over the analysis window. 
+# Seting axis values - If set_axis = True in data_proc section of each plot_grp the yaxis for the plot will be set based on the values specified in the obs section for each variable. If set_axis is set to False, then defaults will be used. 'vmin_plot' and 'vmax_plot' are needed for 'timeseries', 'spatial_overlay', and 'boxplot'. 'vdiff_plot' is needed for 'spatial_bias' plots and'ty_scale' is needed for 'taylor' plots. 'nlevels' or the number of levels used in the contour plot can also optionally be provided for spatial_overlay plot. If set_axis = True and the proper limits are not provided in the obs section, a warning will print, and the plot will be created using the default limits.
+analysis:
+  start_time: '2022-09-11-06:00:00' #UTC
+  end_time: '2022-09-12-06:00:00' #UTC
+  output_dir: /wrk/charkins/melodies_monet/aircraft/develop_aircraft_mobile/Output_hrrr-smoke #Opt if not specified plots stored in code directory.
+  debug: True
+model:
+  hrrr-smoke: # model label
+    # files: /wrk/d2/rschwantes/wrf/firex_mech/qzhu/run_CONUS_fv19_BEIS_1.0xISO_RACM_v4.2.2_racm_berk_vcp_noI_phot_soa/0905/*
+    files: /wrk/users/charkins/megan_mobile_data/HRRR/aqm_HRRR-Smoke_2022091106.nc.subset.nc
+    mod_type: random
+    #mod_kwargs: 
+    #  mech: 'racm_esrl_vcp'
+    radius_of_influence: 12000 #meters
+    mapping: #model species name : obs species name
+      mobile_fire:
+        PM2_5_DRY: 'PM2.5_5min'
+        'TMP_2maboveground': 'Temperature_5min'
+    plot_kwargs: #Opt
+      color: 'dodgerblue'
+      marker: '^'
+      linestyle: ':' 
+obs:
+  mobile_fire: # obs label
+    filename: '/wrk/users/charkins/megan_mobile_data/Fire_obs_all/treated_final_modtime.csv'
+    obs_type: mobile
+    resample: '600S' 
+    time_var: 'time_5min'
+    variables: #Opt 
+      'PM2.5_5min':
+        unit_scale: 1 #Opt Scaling factor 
+        unit_scale_method: '*' #Opt Multiply = '*' , Add = '+', subtract = '-', divide = '/'
+        #nan_value: -777777 # Opt Set this value to NaN
+        #LLOD_value: -888888 # Opt Set this value to LLOD_setvalue
+        #LLOD_setvalue: 0.0 # Opt Set LLOD_value=LLOD_setvalue, applied AFTER unit_scale and obs_unit
+        ylabel_plot: 'PM2.5 (units?)'
+        vmin_plot: 15.0 #Opt Min for y-axis during plotting. To apply to a plot, change restrict_yaxis = True.
+        vmax_plot: 55.0 #Opt Max for y-axis during plotting. To apply to a plot, change restrict_yaxis = True.
+        #vdiff_plot: 20.0 #Opt +/- range to use in bias plots. To apply to a plot, change restrict_yaxis = True.
+        # nlevels_plot: 21 #Opt number of levels used in colorbar for contourf plot.
+      'Temperature_5min':
+        unit_scale: 273.15 #Opt Scaling factor 
+        unit_scale_method: '+' #Opt Multiply = '*' , Add = '+', subtract = '-', divide = '/'
+        #nan_value: -777777 # Set this value to NaN
+        #LLOD_value: -888888 # Opt Set this value to LLOD_setvalue
+        #LLOD_setvalue: 0.0 # Opt Set LLOD_value=LLOD_setvalue, applied AFTER unit_scale and obs_unit
+        ylabel_plot: 'Temperature (K)' #Optional to set ylabel so can include units and/or instr etc.
+        #vmin_plot: 0.0 #Opt Min for y-axis during plotting. To apply to a plot, change restrict_yaxis = True.
+        #vmax_plot: 20.0 #Opt Max for y-axis during plotting. To apply to a plot, change restrict_yaxis = True.
+        #vdiff_plot: 15.0 #Opt +/- range to use in bias plots. To apply to a plot, change restrict_yaxis = True.
+        #nlevels_plot: 21 #Opt number of levels used in colorbar for contourf plot.
+      'Latitude_5min':
+            rename: latitude # name to convert this variable to
+            unit_scale: 1 #Opt Scaling factor 
+            unit_scale_method: '*' #Opt Multiply = '*' , Add = '+', subtract = '-', divide = '/'
+      'Longitude_5min':
+            rename: longitude # name to convert this variable to
+            unit_scale: 1 #Opt Scaling factor 
+            unit_scale_method: '*' #Opt Multiply = '*' , Add = '+', subtract = '-', divide = '/'
+plots:
+  plot_grp1:
+    type: 'timeseries' # plot type
+    fig_kwargs: #Opt to define figure options
+      figsize: [12,6] # figure size if multiple plots
+    default_plot_kwargs: # Opt to define defaults for all plots. Model kwargs overwrite these.
+      linewidth: 2.0
+      markersize: 10.
+    text_kwargs: #Opt
+      fontsize: 18.
+    domain_type: ['all'] #List of domain types: 'all' or any domain in obs file. (e.g., airnow: epa_region, state_name, siteid, etc.) 
+    domain_name: ['CONUS'] #List of domain names. If domain_type = all domain_name is used in plot title.
+    data: ['mobile_fire_hrrr-smoke'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
+    data_proc:
+      rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
+      ts_select_time: 'time' #Time used for avg and plotting: Options: 'time' for UTC or 'time_local'
+      ts_avg_window: null # Options: None for no averaging or list pandas resample rule (e.g., 'H', 'D')
+      set_axis: False #If select True, add vmin_plot and vmax_plot for each variable in obs.
+  plot_grp2:
+    type: 'taylor' # plot type
+    fig_kwargs: #Opt to define figure options
+      figsize: [8,8] # figure size if multiple plots
+    default_plot_kwargs: # Opt to define defaults for all plots. Model kwargs overwrite these.
+      linewidth: 2.0
+      markersize: 10.
+    text_kwargs: #Opt
+      fontsize: 16.
+    domain_type: ['all'] #List of domain types: 'all' or any domain in obs file. (e.g., airnow: epa_region, state_name, siteid, etc.) 
+    domain_name: ['CONUS'] #List of domain names. If domain_type = all domain_name is used in plot title.
+    data: ['mobile_fire_hrrr-smoke'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
+    data_proc:
+      rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
+      set_axis: True #If select True, add ty_scale for each variable in obs.
+  plot_grp3:
+    type: 'boxplot' # plot type
+    fig_kwargs: #Opt to define figure options
+      figsize: [8, 6] # figure size 
+    text_kwargs: #Opt
+      fontsize: 20.
+    domain_type: ['all'] #List of domain types: 'all' or any domain in obs file. (e.g., airnow: epa_region, state_name, siteid, etc.) 
+    domain_name: ['CONUS'] #List of domain names. If domain_type = all domain_name is used in plot title.
+    data: ['mobile_fire_hrrr-smoke'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
+    data_proc:
+      rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
+      set_axis: False #If select True, add vmin_plot and vmax_plot for each variable in obs.
+
+stats:
+  #Stats require positive numbers, so if you want to calculate temperature use Kelvin!
+  #Wind direction has special calculations for AirNow if obs name is 'WD'
+  stat_list: ['MB', 'MdnB','R2', 'RMSE'] #List stats to calculate. Dictionary of definitions included in plots/proc_stats.py Only stats listed below are currently working.
+  #Full calc list ['STDO', 'STDP', 'MdnNB','MdnNE','NMdnGE', 'NO','NOP','NP','MO','MP', 'MdnO', 'MdnP', 'RM', 'RMdn', 'MB', 'MdnB', 'NMB', 'NMdnB', 'FB', 'ME','MdnE','NME', 'NMdnE', 'FE', 'R2', 'RMSE','d1','E1', 'IOA', 'AC']
+  round_output: 2 #Opt, defaults to rounding to 3rd decimal place.
+  output_table: False #Always outputs a .txt file. Optional to also output as a table.
+  output_table_kwargs: #Opt 
+    figsize: [7, 3] # figure size 
+    fontsize: 12.
+    xscale: 1.4
+    yscale: 1.4
+    edges: 'horizontal'
+  domain_type: ['all'] #List of domain types: 'all' or any domain in obs file. (e.g., airnow: epa_region, state_name, siteid, etc.) 
+  domain_name: ['CONUS'] #List of domain names. If domain_type = all domain_name is used in plot title.
+  data: ['mobile_fire_hrrr-smoke'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
+  

--- a/examples/yaml/control_hrrr-smoke_mobile.yaml
+++ b/examples/yaml/control_hrrr-smoke_mobile.yaml
@@ -10,12 +10,8 @@ analysis:
   debug: True
 model:
   hrrr-smoke: # model label
-    # files: /wrk/d2/rschwantes/wrf/firex_mech/qzhu/run_CONUS_fv19_BEIS_1.0xISO_RACM_v4.2.2_racm_berk_vcp_noI_phot_soa/0905/*
     files: /wrk/users/charkins/megan_mobile_data/HRRR/aqm_HRRR-Smoke_2022091106.nc.subset.nc
     mod_type: random
-    #mod_kwargs: 
-    #  mech: 'racm_esrl_vcp'
-    radius_of_influence: 12000 #meters
     mapping: #model species name : obs species name
       mobile_fire:
         PM2_5_DRY: 'PM2.5_5min'
@@ -34,25 +30,12 @@ obs:
       'PM2.5_5min':
         unit_scale: 1 #Opt Scaling factor 
         unit_scale_method: '*' #Opt Multiply = '*' , Add = '+', subtract = '-', divide = '/'
-        #nan_value: -777777 # Opt Set this value to NaN
-        #LLOD_value: -888888 # Opt Set this value to LLOD_setvalue
-        #LLOD_setvalue: 0.0 # Opt Set LLOD_value=LLOD_setvalue, applied AFTER unit_scale and obs_unit
+
         ylabel_plot: 'PM2.5 (units?)'
-        vmin_plot: 15.0 #Opt Min for y-axis during plotting. To apply to a plot, change restrict_yaxis = True.
-        vmax_plot: 55.0 #Opt Max for y-axis during plotting. To apply to a plot, change restrict_yaxis = True.
-        #vdiff_plot: 20.0 #Opt +/- range to use in bias plots. To apply to a plot, change restrict_yaxis = True.
-        # nlevels_plot: 21 #Opt number of levels used in colorbar for contourf plot.
       'Temperature_5min':
         unit_scale: 273.15 #Opt Scaling factor 
         unit_scale_method: '+' #Opt Multiply = '*' , Add = '+', subtract = '-', divide = '/'
-        #nan_value: -777777 # Set this value to NaN
-        #LLOD_value: -888888 # Opt Set this value to LLOD_setvalue
-        #LLOD_setvalue: 0.0 # Opt Set LLOD_value=LLOD_setvalue, applied AFTER unit_scale and obs_unit
         ylabel_plot: 'Temperature (K)' #Optional to set ylabel so can include units and/or instr etc.
-        #vmin_plot: 0.0 #Opt Min for y-axis during plotting. To apply to a plot, change restrict_yaxis = True.
-        #vmax_plot: 20.0 #Opt Max for y-axis during plotting. To apply to a plot, change restrict_yaxis = True.
-        #vdiff_plot: 15.0 #Opt +/- range to use in bias plots. To apply to a plot, change restrict_yaxis = True.
-        #nlevels_plot: 21 #Opt number of levels used in colorbar for contourf plot.
       'Latitude_5min':
             rename: latitude # name to convert this variable to
             unit_scale: 1 #Opt Scaling factor 

--- a/examples/yaml/control_wrfchem_ground.yaml
+++ b/examples/yaml/control_wrfchem_ground.yaml
@@ -1,0 +1,107 @@
+# General Description:  
+# Any key that is specific for a plot type will begin with ts for timeseries, ty for taylor
+# Opt: Specifying the variable or variable group is optional
+# For now all plots except time series average over the analysis window. 
+# Seting axis values - If set_axis = True in data_proc section of each plot_grp the yaxis for the plot will be set based on the values specified in the obs section for each variable. If set_axis is set to False, then defaults will be used. 'vmin_plot' and 'vmax_plot' are needed for 'timeseries', 'spatial_overlay', and 'boxplot'. 'vdiff_plot' is needed for 'spatial_bias' plots and'ty_scale' is needed for 'taylor' plots. 'nlevels' or the number of levels used in the contour plot can also optionally be provided for spatial_overlay plot. If set_axis = True and the proper limits are not provided in the obs section, a warning will print, and the plot will be created using the default limits.
+analysis:
+  start_time: '2021-07-25-00:00:00' #UTC
+  end_time: '2021-07-25-23:00:00' #UTC
+  output_dir: /wrk/charkins/melodies_monet/aircraft/develop_aircraft_ground/Output #Opt if not specified plots stored in code directory.
+  debug: True
+model:
+  wrfchem_v4.2: # model label
+    # files: /wrk/d2/rschwantes/wrf/firex_mech/qzhu/run_CONUS_fv19_BEIS_1.0xISO_RACM_v4.2.2_racm_berk_vcp_noI_phot_soa/0905/*
+    files: /wrk/users/charkins/MM_data/pasadena_ground_ict/corresponding_model/0725/wrfout_d01_2021-07-25_*
+    mod_type: 'wrfchem'
+    mod_kwargs: 
+      mech: 'racm_esrl_vcp'
+    radius_of_influence: 12000 #meters
+    mapping: #model species name : obs species name
+      pasadena_ground:
+        PM2_5_DRY: "AerComp_OrganicAerosol_PM1" # not correct species pairing but using as example
+    plot_kwargs: #Opt
+      color: 'dodgerblue'
+      marker: '^'
+      linestyle: ':' 
+obs:
+  pasadena_ground: # obs label
+    filename: '/wrk/users/charkins/MM_data/pasadena_ground_ict/20210725/recap-CIT-AMS1-NR-PM1_CITLL_20210725_RB.ict'
+    obs_type: ground
+    ground_coordinate: {'latitude':34.136363,'longitude':-118.126817}
+    #resample: '600S' #10 min so works on Hera as a test. Can comment this if submitting a job. 
+    variables: #Opt 
+      'AerComp_OrganicAerosol_PM1': 
+        unit_scale: 1 #Opt Scaling factor 
+        unit_scale_method: '*' #Opt Multiply = '*' , Add = '+', subtract = '-', divide = '/'
+        ylabel_plot: 'PM1 (units?)'
+      # 'Latitude_YANG':
+            # rename: latitude # name to convert this variable to
+            # unit_scale: 1 #Opt Scaling factor 
+            # unit_scale_method: '*' #Opt Multiply = '*' , Add = '+', subtract = '-', divide = '/'
+      # 'Longitude_YANG':
+            # rename: longitude # name to convert this variable to
+            # unit_scale: 1 #Opt Scaling factor 
+            # unit_scale_method: '*' #Opt Multiply = '*' , Add = '+', subtract = '-', divide = '/'
+plots:
+  plot_grp1:
+    type: 'timeseries' # plot type
+    fig_kwargs: #Opt to define figure options
+      figsize: [12,6] # figure size if multiple plots
+    default_plot_kwargs: # Opt to define defaults for all plots. Model kwargs overwrite these.
+      linewidth: 2.0
+      markersize: 10.
+    text_kwargs: #Opt
+      fontsize: 18.
+    domain_type: ['all'] #List of domain types: 'all' or any domain in obs file. (e.g., airnow: epa_region, state_name, siteid, etc.) 
+    domain_name: ['CONUS'] #List of domain names. If domain_type = all domain_name is used in plot title.
+    data: ['pasadena_ground_wrfchem_v4.2'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
+    data_proc:
+      rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
+      ts_select_time: 'time' #Time used for avg and plotting: Options: 'time' for UTC or 'time_local'
+      ts_avg_window: 'H' # Options: None for no averaging or list pandas resample rule (e.g., 'H', 'D')
+      set_axis: False #If select True, add vmin_plot and vmax_plot for each variable in obs.
+  plot_grp2:
+    type: 'taylor' # plot type
+    fig_kwargs: #Opt to define figure options
+      figsize: [8,8] # figure size if multiple plots
+    default_plot_kwargs: # Opt to define defaults for all plots. Model kwargs overwrite these.
+      linewidth: 2.0
+      markersize: 10.
+    text_kwargs: #Opt
+      fontsize: 16.
+    domain_type: ['all'] #List of domain types: 'all' or any domain in obs file. (e.g., airnow: epa_region, state_name, siteid, etc.) 
+    domain_name: ['CONUS'] #List of domain names. If domain_type = all domain_name is used in plot title.
+    data: ['pasadena_ground_wrfchem_v4.2'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
+    data_proc:
+      rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
+      set_axis: True #If select True, add ty_scale for each variable in obs.
+  plot_grp3:
+    type: 'boxplot' # plot type
+    fig_kwargs: #Opt to define figure options
+      figsize: [8, 6] # figure size 
+    text_kwargs: #Opt
+      fontsize: 20.
+    domain_type: ['all'] #List of domain types: 'all' or any domain in obs file. (e.g., airnow: epa_region, state_name, siteid, etc.) 
+    domain_name: ['CONUS'] #List of domain names. If domain_type = all domain_name is used in plot title.
+    data: ['pasadena_ground_wrfchem_v4.2'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
+    data_proc:
+      rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
+      set_axis: False #If select True, add vmin_plot and vmax_plot for each variable in obs.
+
+
+stats:
+  #Stats require positive numbers, so if you want to calculate temperature use Kelvin!
+  #Wind direction has special calculations for AirNow if obs name is 'WD'
+  stat_list: ['MB', 'MdnB','R2', 'RMSE'] #List stats to calculate. Dictionary of definitions included in plots/proc_stats.py Only stats listed below are currently working.
+  #Full calc list ['STDO', 'STDP', 'MdnNB','MdnNE','NMdnGE', 'NO','NOP','NP','MO','MP', 'MdnO', 'MdnP', 'RM', 'RMdn', 'MB', 'MdnB', 'NMB', 'NMdnB', 'FB', 'ME','MdnE','NME', 'NMdnE', 'FE', 'R2', 'RMSE','d1','E1', 'IOA', 'AC']
+  round_output: 2 #Opt, defaults to rounding to 3rd decimal place.
+  output_table: False #Always outputs a .txt file. Optional to also output as a table.
+  output_table_kwargs: #Opt 
+    figsize: [7, 3] # figure size 
+    fontsize: 12.
+    xscale: 1.4
+    yscale: 1.4
+    edges: 'horizontal'
+  domain_type: ['all'] #List of domain types: 'all' or any domain in obs file. (e.g., airnow: epa_region, state_name, siteid, etc.) 
+  domain_name: ['CONUS'] #List of domain names. If domain_type = all domain_name is used in plot title.
+  data: ['pasadena_ground_wrfchem_v4.2'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label

--- a/examples/yaml/control_wrfchem_ground.yaml
+++ b/examples/yaml/control_wrfchem_ground.yaml
@@ -10,12 +10,10 @@ analysis:
   debug: True
 model:
   wrfchem_v4.2: # model label
-    # files: /wrk/d2/rschwantes/wrf/firex_mech/qzhu/run_CONUS_fv19_BEIS_1.0xISO_RACM_v4.2.2_racm_berk_vcp_noI_phot_soa/0905/*
     files: /wrk/users/charkins/MM_data/pasadena_ground_ict/corresponding_model/0725/wrfout_d01_2021-07-25_*
     mod_type: 'wrfchem'
     mod_kwargs: 
       mech: 'racm_esrl_vcp'
-    radius_of_influence: 12000 #meters
     mapping: #model species name : obs species name
       pasadena_ground:
         PM2_5_DRY: "AerComp_OrganicAerosol_PM1" # not correct species pairing but using as example
@@ -34,14 +32,7 @@ obs:
         unit_scale: 1 #Opt Scaling factor 
         unit_scale_method: '*' #Opt Multiply = '*' , Add = '+', subtract = '-', divide = '/'
         ylabel_plot: 'PM1 (units?)'
-      # 'Latitude_YANG':
-            # rename: latitude # name to convert this variable to
-            # unit_scale: 1 #Opt Scaling factor 
-            # unit_scale_method: '*' #Opt Multiply = '*' , Add = '+', subtract = '-', divide = '/'
-      # 'Longitude_YANG':
-            # rename: longitude # name to convert this variable to
-            # unit_scale: 1 #Opt Scaling factor 
-            # unit_scale_method: '*' #Opt Multiply = '*' , Add = '+', subtract = '-', divide = '/'
+
 plots:
   plot_grp1:
     type: 'timeseries' # plot type

--- a/melodies_monet/driver.py
+++ b/melodies_monet/driver.py
@@ -188,6 +188,14 @@ class observation:
         self.filter_obs()
     
     def add_coordinates_ground(self):
+        """Add latitude and longitude coordinates to data when the observation type is ground and 
+        ground_coordinate is specified
+        
+        Returns
+        -------
+        None
+        """
+        
         # If ground site
         if self.obs_type == 'ground':
             if self.ground_coordinate and isinstance(self.ground_coordinate,dict):

--- a/melodies_monet/driver.py
+++ b/melodies_monet/driver.py
@@ -180,11 +180,21 @@ class observation:
         except Exception as e:
             print('something happened opening file:', e)
             return
-
+        
+        self.add_coordinates_ground() # If ground site then add coordinates based on yaml if necessary
         self.mask_and_scale()  # mask and scale values from the control values
         self.rename_vars() # rename any variables as necessary 
         self.resample_data()
         self.filter_obs()
+    
+    def add_coordinates_ground(self):
+        # If ground site
+        if self.obs_type == 'ground':
+            if self.ground_coordinate and isinstance(self.ground_coordinate,dict):
+                self.obj['latitude'] = xr.ones_like(self.obj['time'],dtype=np.float64)*self.ground_coordinate['latitude']
+                self.obj['longitude'] = xr.ones_like(self.obj['time'],dtype=np.float64)*self.ground_coordinate['longitude']
+            elif self.ground_coordinate and ~isinstance(self.ground_coordinate,dict): 
+                raise TypeError(f'The ground_coordinate option must be specified as a dict with keys latitude and longitude.')
 
     def rename_vars(self):
         """Rename any variables in observation with rename set.
@@ -785,6 +795,8 @@ class analysis:
                     o.resample = self.control_dict['obs'][obs]['resample']
                 if 'time_var' in self.control_dict['obs'][obs].keys():
                     o.time_var = self.control_dict['obs'][obs]['time_var']
+                if 'ground_coordinate' in self.control_dict['obs'][obs].keys():
+                    o.ground_coordinate = self.control_dict['obs'][obs]['ground_coordinate']
                 o.open_obs(time_interval=time_interval)
                 self.obs[o.label] = o
 
@@ -864,7 +876,7 @@ class analysis:
                     p.obj = p.fix_paired_xarray(dset=p.obj)
                     # write_util.write_ncf(p.obj,p.filename) # write out to file
                     
-                                # if aircraft (aircraft observation)
+                # if aircraft (aircraft observation)
                 elif obs.obs_type.lower() == 'aircraft':
                     from .util.tools import vert_interp
                     # convert this to pandas dataframe unless already done because second time paired this obs
@@ -900,8 +912,9 @@ class analysis:
                     self.paired[label] = p
                     # write_util.write_ncf(p.obj,p.filename) # write out to file
                 
-                elif obs.obs_type.lower() == 'mobile':
-                    from .util.tools import mobile_pair
+                # If mobile surface data or single ground site surface data
+                elif obs.obs_type.lower() == 'mobile' or obs.obs_type.lower() == 'ground':
+                    from .util.tools import mobile_and_ground_pair
                     # convert this to pandas dataframe unless already done because second time paired this obs
                     if not isinstance(obs.obj, pd.DataFrame):
                         obs.obj = obs.obj.to_dataframe()
@@ -919,11 +932,14 @@ class analysis:
                     #Interpolate based on time in the observations
                     ds_model = ds_model.interp(time=ds_model.time_obs.squeeze())
                     
-                    paired_data = mobile_pair(ds_model,obs.obj,keys+mod_vars)
+                    paired_data = mobile_and_ground_pair(ds_model,obs.obj,keys+mod_vars)
                     print('After pairing: ', paired_data)
                     # this outputs as a pandas dataframe.  Convert this to xarray obj
                     p = pair()
-                    p.type = 'mobile'
+                    if obs.obs_type.lower() == 'mobile':
+                        p.type = 'mobile'
+                    elif obs.obs_type.lower() == 'ground':
+                        p.type = 'ground'
                     p.radius_of_influence = None
                     p.obs = obs.label
                     p.model = mod.label

--- a/melodies_monet/driver.py
+++ b/melodies_monet/driver.py
@@ -814,6 +814,8 @@ class analysis:
                 obs_vars = [mod.mapping[obs_to_pair][key] for key in keys]
                 if mod.variable_dict is not None:
                     mod_vars = [key for key in mod.variable_dict.keys()]
+                else:
+                    mod_vars = []
                 
                 # unstructured grid check - lon/lat variables should be explicitly added 
                 # in addition to comparison variables
@@ -897,7 +899,41 @@ class analysis:
                     label = "{}_{}".format(p.obs, p.model)
                     self.paired[label] = p
                     # write_util.write_ncf(p.obj,p.filename) # write out to file
+                
+                elif obs.obs_type.lower() == 'mobile':
+                    from .util.tools import mobile_pair
+                    # convert this to pandas dataframe unless already done because second time paired this obs
+                    if not isinstance(obs.obj, pd.DataFrame):
+                        obs.obj = obs.obj.to_dataframe()
                     
+                    #drop any variables where coords NaN
+                    obs.obj = obs.obj.reset_index().dropna(subset=['latitude','longitude']).set_index('time')
+                    
+                    # do the facy trick to convert to get something useful for MONET
+                    # this converts to dimensions of x and y
+                    # you may want to make pressure / msl a coordinate too
+                    new_ds_obs = obs.obj.rename_axis('time_obs').reset_index().monet._df_to_da().set_coords(['time_obs'])
+                    
+                    #Nearest neighbor approach to find closest grid cell to each point.
+                    ds_model = m.util.combinetool.combine_da_to_da(model_obj,new_ds_obs,merge=False)
+                    #Interpolate based on time in the observations
+                    ds_model = ds_model.interp(time=ds_model.time_obs.squeeze())
+                    
+                    paired_data = mobile_pair(ds_model,obs.obj,keys+mod_vars)
+                    print('After pairing: ', paired_data)
+                    # this outputs as a pandas dataframe.  Convert this to xarray obj
+                    p = pair()
+                    p.type = 'mobile'
+                    p.radius_of_influence = None
+                    p.obs = obs.label
+                    p.model = mod.label
+                    p.model_vars = keys
+                    p.obs_vars = obs_vars
+                    p.filename = '{}_{}.nc'.format(p.obs, p.model)
+                    p.obj = paired_data.set_index('time').to_xarray().expand_dims('x').transpose('time','x')
+                    label = "{}_{}".format(p.obs, p.model)
+                    self.paired[label] = p
+                
                 # TODO: add other network types / data types where (ie flight, satellite etc)
 
     def concat_pairs(self):

--- a/melodies_monet/util/read_util.py
+++ b/melodies_monet/util/read_util.py
@@ -208,6 +208,9 @@ def read_aircraft_obs_csv(filename,time_var=None):
         df.rename(columns={time_var:'time'},inplace=True)
         df['time']  = pd.to_datetime(df['time'])
         
+    # Sort the values based on time
+    df.sort_values(by='time',inplace=True,ignore_index=True)
+        
     df.set_index('time',inplace=True)
     
     return xr.Dataset.from_dataframe(df)

--- a/melodies_monet/util/tools.py
+++ b/melodies_monet/util/tools.py
@@ -320,7 +320,7 @@ def vert_interp(ds_model,df_obs,var_name_list):
 
     return final_df_model
 
-def mobile_pair(ds_model,df_obs, var_name_list):
+def mobile_and_ground_pair(ds_model,df_obs, var_name_list):
     import xarray as xr
     from pandas import merge_asof, Series
     
@@ -338,8 +338,6 @@ def mobile_pair(ds_model,df_obs, var_name_list):
             out = ds_model[var_name]
             out.name = var_name
             var_out_list.append(out)
-    
-    #breakpoint()
     
     df_model = xr.merge(var_out_list).to_dataframe().reset_index()
     df_model.drop(labels=['x','y','time_obs'], axis=1, inplace=True)

--- a/melodies_monet/util/tools.py
+++ b/melodies_monet/util/tools.py
@@ -320,3 +320,33 @@ def vert_interp(ds_model,df_obs,var_name_list):
 
     return final_df_model
 
+def mobile_pair(ds_model,df_obs, var_name_list):
+    import xarray as xr
+    from pandas import merge_asof, Series
+    
+    var_out_list = []
+    # Extract just the surface level data from correct model variables
+    # if there is a z dimension, extract the surface, otherwise assume data is at surface and issue warning
+    if 'z' in ds_model.dims:
+        for var_name in var_name_list:
+            out = ds_model[var_name].isel(z=0)
+            out.name = var_name
+            var_out_list.append(out)
+    else:
+        print('WARNING: No z dimension in model, assuming all data at surface.')
+        for var_name in var_name_list:
+            out = ds_model[var_name]
+            out.name = var_name
+            var_out_list.append(out)
+    
+    #breakpoint()
+    
+    df_model = xr.merge(var_out_list).to_dataframe().reset_index()
+    df_model.drop(labels=['x','y','time_obs'], axis=1, inplace=True)
+
+    final_df_model = merge_asof(df_obs, df_model, 
+                            by=['latitude', 'longitude'], 
+                            on='time', direction='nearest')
+
+    return final_df_model
+


### PR DESCRIPTION
This is a draft PR for modifications to the develop_aircraft branch to add the ability to pair with mobile drive data and data from stationary ground sites. 

Currently the functionality for pairing with mobile drive data is implemented and I will add the ability to pair with data from a single ground site, and clean up the code tomorrow. 