### PR TITLE
Mask -1 in AERONET test

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -199,6 +199,7 @@ linkcheck_ignore = [
     # Sphinx 4.5 linkcheck having problem:
     "https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account",
 ]
+user_agent = "Mozilla/5.0 (X11; Linux x86_64; rv:25.0) Gecko/20100101 Firefox/25.0"
 
 autosectionlabel_prefix_document = True
 autosectionlabel_maxdepth = 2

--- a/melodies_monet/tests/test_get_data_cli.py
+++ b/melodies_monet/tests/test_get_data_cli.py
@@ -29,11 +29,11 @@ def test_get_aeronet(tmp_path):
     # since positions may differ due to NaN-lat/lon dropping or such
     ds = xr.open_dataset(tmp_path / fn).squeeze().swap_dims(x="siteid")
     ds0 = ds0_aeronet.sel(time=ds.time).squeeze().swap_dims(x="siteid")
-    # TODO: seems original loading missing value as -1 (on purpose, due to compress routine)
+    # NOTE: -1 in ds0 indicates missing value, due to compress routine
     
     assert not ds.identical(ds0)
     assert ds.time.equals(ds0.time)
-    # assert (np.abs(ds.aod_551nm - ds0.aod_551nm) < 1e-9).all()
+    ds0["aod_551nm"] = ds0["aod_551nm"].where(ds0["aod_551nm"] != -1)
     assert (np.abs(ds.aod_551nm - ds0.aod_551nm).to_series().dropna() < 1e-9).all()
     # - Many more site IDs in ds0 (400 vs 283), and one that is in ds but not ds0
     # - In the above, only two sites


### PR DESCRIPTION
With [recent AERONET web service change](https://github.com/noaa-oar-arl/monetio/issues/100#issuecomment-1728561553), now we are getting a few places (sites 'USC_SEAPRISM', 'USC_SEAPRISM_2', for AOD 551) where old dataset we are checking against was -1 but the new dataset had some values, giving diffs we don't want to test.