### PR TITLE
Add pandas pin to install commands in docs

### DIFF
--- a/docs/develop/developers_guide.rst
+++ b/docs/develop/developers_guide.rst
@@ -74,7 +74,7 @@ these instructions:
 
        $ conda create --name melodies-monet python=3.9
        $ conda activate melodies-monet
-       $ conda install -y -c conda-forge pyyaml monet monetio netcdf4 wrf-python typer rich pooch jupyterlab
+       $ conda install -y -c conda-forge pyyaml pandas=1 monet monetio netcdf4 wrf-python typer rich pooch jupyterlab
 
 (b) Clone [#clone]_ and link the latest development versions of MONET and MONETIO from GitHub to
     your conda environment::

--- a/docs/tutorial/installation.rst
+++ b/docs/tutorial/installation.rst
@@ -34,7 +34,7 @@ First create and activate a conda environment::
 
 Add dependencies from conda-forge::
 
-    $ conda install -y -c conda-forge pyyaml monet monetio netcdf4 wrf-python typer rich pooch
+    $ conda install -y -c conda-forge pyyaml pandas=1 monet monetio netcdf4 wrf-python typer rich pooch
 
 Now, install the stable branch of MELODIES MONET to the environment::
 


### PR DESCRIPTION
As discussed today, some MONETIO readers ([including](https://github.com/noaa-oar-arl/monetio/issues/111) AirNow and AERONET) and MM data processing routines[^1] don't work with pandas v2 yet.

[^1]: At least I thought I had a case of this at some point. Yes, just found one again, `df_mean=df.groupby(['siteid'],as_index=False).mean()` fails in spatial overlay plot.