### PR TITLE
CLI: initial save/read paired dataset support for `melodies-monet run`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,12 +62,33 @@ jobs:
           done
           cd -
 
+      - name: Prepare idealized save/read cases
+        shell: python
+        run: |
+          from copy import deepcopy
+          import yaml
+
+          with open('docs/examples/control_idealized.yaml') as f:
+            ctl = yaml.safe_load(f)
+          assert {'save', 'read'} < ctl['analysis'].keys()
+
+          ctl_save = deepcopy(ctl)
+          del ctl_save['analysis']['read']
+          with open('docs/examples/control_idealized_save.yaml', 'w') as f:
+            yaml.safe_dump(ctl_save, f)
+
+          ctl_read = deepcopy(ctl)
+          del ctl_read['analysis']['save']
+          with open('docs/examples/control_idealized_read.yaml', 'w') as f:
+            yaml.safe_dump(ctl_read, f)
+
       - name: Check CLI works
         run: |
           cd docs/examples
           melodies-monet --version
           python -m melodies_monet --version
-          melodies-monet run control_idealized.yaml
+          melodies-monet run control_idealized_save.yaml
+          melodies-monet run control_idealized_read.yaml
           cd -
 
   docs:

--- a/melodies_monet/_cli.py
+++ b/melodies_monet/_cli.py
@@ -146,7 +146,14 @@ def run(
         an.open_obs()
 
     with _timer("Pairing"):
-        an.pair_data()
+        if an.read is not None:
+            an.read_analysis()
+        else:
+            an.pair_data()
+
+    if an.save is not None:
+        with _timer("Saving paired datasets"):
+            an.save_analysis()
 
     if an.control_dict.get("plots") is not None:
         with _timer("Plotting and saving the figures"), _ignore_pandas_numeric_only_futurewarning():

--- a/melodies_monet/util/read_util.py
+++ b/melodies_monet/util/read_util.py
@@ -127,12 +127,12 @@ def read_analysis_ncf(filenames,xr_kws={}):
     import xarray as xr
     
     if len(filenames)==1:
-        print('Reading: ', filenames[0])
+        print('Reading:', filenames[0])
         ds_out = xr.open_dataset(filenames[0],**xr_kws)
         
     elif len(filenames)>1:
         for count, file in enumerate(filenames):
-            print('Reading: ', file)
+            print('Reading:', file)
 
             if count==0:
                 ds_out = xr.open_dataset(file,**xr_kws)


### PR DESCRIPTION
1. if `analysis.read` is present in the config, read saved paired datasets instead of pairing
2. if `analysis.save` is present in the config, save paired datasets

This is something I've been using for a while, and it's been working fine.