### PR TITLE
Add variable summing and PM unit conversions for firexaq dataset

### DIFF
--- a/examples/yaml/control_wrfchem_aircraft_sumpmspecies.yaml
+++ b/examples/yaml/control_wrfchem_aircraft_sumpmspecies.yaml
@@ -1,0 +1,273 @@
+# General Description:  
+# Any key that is specific for a plot type will begin with ts for timeseries, ty for taylor
+# Opt: Specifying the variable or variable group is optional
+# For now all plots except time series average over the analysis window. 
+# Seting axis values - If set_axis = True in data_proc section of each plot_grp the yaxis for the plot will be set based on the values specified in the obs section for each variable. If set_axis is set to False, then defaults will be used. 'vmin_plot' and 'vmax_plot' are needed for 'timeseries', 'spatial_overlay', and 'boxplot'. 'vdiff_plot' is needed for 'spatial_bias' plots and'ty_scale' is needed for 'taylor' plots. 'nlevels' or the number of levels used in the contour plot can also optionally be provided for spatial_overlay plot. If set_axis = True and the proper limits are not provided in the obs section, a warning will print, and the plot will be created using the default limits.
+analysis:
+  start_time: '2019-09-05-12:00:00' #UTC
+  end_time: '2019-09-06-00:00:00' #UTC
+  output_dir: /wrk/charkins/melodies_monet/aircraft/develop_sumvars/output #/wrk/charkins/melodies_monet/NOAA_CSL_main/test_pull_189_aircraft/output #/wrk/charkins/melodies_monet/aircraft/analysis #Opt if not specified plots stored in code directory.
+  debug: True
+model:
+  wrfchem_v4.2: # model label
+    # files: /wrk/d2/rschwantes/wrf/firex_mech/qzhu/run_CONUS_fv19_BEIS_1.0xISO_RACM_v4.2.2_racm_berk_vcp_noI_phot_soa/0905/*
+    files: /wrk/users/charkins/melodies-monet_data/wrfchem/run_CONUS_fv19_BEIS_1.0xISO_RACM_v4.2.2_racm_berk_vcp_noI_phot_soa/0905/* #/scratch2/BMC/rcm1/qzhu/wrfchem/runs_firex/run_CONUS_fv19_BEIS_1.0xISO_RACM_v4.2.2_racm_vcp_noI_phot/Output/0905/* #/wrk/d2/rschwantes/wrf/firex_mech/qzhu/run_CONUS_fv19_BEIS_1.0xISO_RACM_v4.2.2_racm_berk_vcp_noI_phot_soa/0905/*
+    mod_type: 'wrfchem'
+    mod_kwargs: 
+      mech: 'racm_esrl_vcp'
+    radius_of_influence: 12000 #meters
+    mapping: #model species name : obs species name
+      firexaq:
+        oa_tot: OA_PM1_AMS_JIMENEZ
+        SO4A: Sulfate_PM1_AMS_JIMENEZ
+        NH4A: Ammonium_PM1_AMS_JIMENEZ
+        NO3A: Nitrate_PM1_AMS_JIMENEZ
+        EC: BC_mass_90_550_nm_SCHWARZ
+    variables:
+        'pres_pa_mid':
+            rename: pressure_model # name to convert this variable to, use 'pressure_model' for aircraft obs
+            unit_scale: 1 #Opt Scaling factor 
+            unit_scale_method: '*' #Opt Multiply = '*' , Add = '+', subtract = '-', divide = '/'
+        'temperature_k':
+            rename: temp_model # name to convert this variable to
+            unit_scale: 1 #Opt Scaling factor 
+            unit_scale_method: '*' #Opt Multiply = '*' , Add = '+', subtract = '-', divide = '/'
+    variable_summing:
+      oa_tot:
+        vars: ['orgpai','orgpaj','asoa1i','asoa1j','asoa2i','asoa2j','asoa3i','asoa3j','asoa4i','asoa4j','bsoa1i','bsoa1j','bsoa2i','bsoa2j','bsoa3i','bsoa3j','bsoa4i','bsoa4j'] # Variables from the dataset that should be summed to create a new variable 
+        ylabel_plot: 'Organic Aerosol Total' #Optional to set ylabel so can include units and/or instr etc.
+      SO4A:
+        vars: ['so4aj','so4ai'] # Variables from the dataset that should be summed to create a new variable 
+        ylabel_plot: 'SO4A' #Optional to set ylabel so can include units and/or instr etc.
+      NH4A:
+        vars: ['nh4aj','nh4ai'] # Variables from the dataset that should be summed to create a new variable 
+        ylabel_plot: 'NH4A' #Optional to set ylabel so can include units and/or instr etc.
+      NO3A:
+        vars: ['no3aj','no3ai'] # Variables from the dataset that should be summed to create a new variable 
+        ylabel_plot: 'NO3A' #Optional to set ylabel so can include units and/or instr etc.
+      EC:
+        vars: ['ecj','eci'] # Variables from the dataset that should be summed to create a new variable 
+        ylabel_plot: 'EC' #Optional to set ylabel so can include units and/or instr etc.
+    projection: None
+    plot_kwargs: #Opt
+      color: 'dodgerblue'
+      marker: '^'
+      linestyle: ':' 
+
+obs:
+  firexaq: # obs label
+    filename: '/wrk/d2/rschwantes/obs/firex-aq/R1/10s_merge/firexaq-mrg10-dc8_merge_20190905_R1.ict' #'/scratch2/BMC/rcm1/rhs/obs/firex_20201209/R1/10s_merge/firexaq-mrg10-dc8_merge_20190905_R1.ict'
+    obs_type: aircraft
+    resample: '600S' #10 min so works on Hera as a test. Can comment this if submitting a job. 
+    variables: #Opt 
+      'OA_PM1_AMS_JIMENEZ':
+        unit_scale: 1 #Opt Scaling factor 
+        unit_scale_method: '*' #Opt Multiply = '*' , Add = '+', subtract = '-', divide = '/'
+        nan_value: -777777 # Opt Set this value to NaN
+        LLOD_value: -888888 # Opt Set this value to LLOD_setvalue
+        LLOD_setvalue: 0.0 # Opt Set LLOD_value=LLOD_setvalue, applied AFTER unit_scale and obs_unit
+        ylabel_plot: 'OA_PM1_AMS_JIMENEZ'
+      'Sulfate_PM1_AMS_JIMENEZ':
+        unit_scale: 1 #Opt Scaling factor 
+        unit_scale_method: '*' #Opt Multiply = '*' , Add = '+', subtract = '-', divide = '/'
+        nan_value: -777777 # Opt Set this value to NaN
+        LLOD_value: -888888 # Opt Set this value to LLOD_setvalue
+        LLOD_setvalue: 0.0 # Opt Set LLOD_value=LLOD_setvalue, applied AFTER unit_scale and obs_unit
+        ylabel_plot: 'Sulfate_PM1_AMS_JIMENEZ'
+      'Ammonium_PM1_AMS_JIMENEZ':
+        unit_scale: 1 #Opt Scaling factor 
+        unit_scale_method: '*' #Opt Multiply = '*' , Add = '+', subtract = '-', divide = '/'
+        nan_value: -777777 # Opt Set this value to NaN
+        LLOD_value: -888888 # Opt Set this value to LLOD_setvalue
+        LLOD_setvalue: 0.0 # Opt Set LLOD_value=LLOD_setvalue, applied AFTER unit_scale and obs_unit
+        ylabel_plot: 'Ammonium_PM1_AMS_JIMENEZ'
+      'Nitrate_PM1_AMS_JIMENEZ':
+        unit_scale: 1 #Opt Scaling factor 
+        unit_scale_method: '*' #Opt Multiply = '*' , Add = '+', subtract = '-', divide = '/'
+        nan_value: -777777 # Opt Set this value to NaN
+        LLOD_value: -888888 # Opt Set this value to LLOD_setvalue
+        LLOD_setvalue: 0.0 # Opt Set LLOD_value=LLOD_setvalue, applied AFTER unit_scale and obs_unit
+        ylabel_plot: 'Nitrate_PM1_AMS_JIMENEZ'
+      'BC_mass_90_550_nm_SCHWARZ':
+        unit_scale: 1 #Opt Scaling factor 
+        unit_scale_method: '*' #Opt Multiply = '*' , Add = '+', subtract = '-', divide = '/'
+        nan_value: -777777 # Opt Set this value to NaN
+        LLOD_value: -888888 # Opt Set this value to LLOD_setvalue
+        LLOD_setvalue: 0.0 # Opt Set LLOD_value=LLOD_setvalue, applied AFTER unit_scale and obs_unit
+        ylabel_plot: 'BC_mass_90_550_nm_SCHWARZ'
+      'Latitude_YANG':
+            rename: latitude # name to convert this variable to
+            unit_scale: 1 #Opt Scaling factor 
+            unit_scale_method: '*' #Opt Multiply = '*' , Add = '+', subtract = '-', divide = '/'
+      'Longitude_YANG':
+            rename: longitude # name to convert this variable to
+            unit_scale: 1 #Opt Scaling factor 
+            unit_scale_method: '*' #Opt Multiply = '*' , Add = '+', subtract = '-', divide = '/'
+      'P_BUI':
+            rename: pressure_obs # name to convert this variable to
+            unit_scale: 100 #Opt Scaling factor 
+            unit_scale_method: '*' #Opt Multiply = '*' , Add = '+', subtract = '-', divide = '/'
+      'T_BUI':
+            rename: temp_obs # name to convert this variable to
+            unit_scale: 1 #Opt Scaling factor 
+            unit_scale_method: '*' #Opt Multiply = '*' , Add = '+', subtract = '-', divide = '/'
+      'MSL_GPS_Altitude_YANG':
+          rename: altitude # name to convert this variable to
+          unit_scale: 1 #Opt Scaling factor 
+          unit_scale_method: '*' #Opt Multiply = '*' , Add = '+', subtract = '-', divide = '/'
+   
+plots:
+  plot_grp1:
+    type: 'timeseries' # plot type
+    fig_kwargs: #Opt to define figure options
+      figsize: [12,6] # figure size if multiple plots
+    default_plot_kwargs: # Opt to define defaults for all plots. Model kwargs overwrite these.
+      linewidth: 2.0
+      markersize: 10.
+    text_kwargs: #Opt
+      fontsize: 18.
+    domain_type: ['all'] #List of domain types: 'all' or any domain in obs file. (e.g., airnow: epa_region, state_name, siteid, etc.) 
+    domain_name: ['CONUS'] #List of domain names. If domain_type = all domain_name is used in plot title.
+    data: ['firexaq_wrfchem_v4.2'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
+    data_proc:
+      #See 'altitde_yax2' list below for secondary y-axis options
+      #altitude_variable: altitude  
+      #altitude_ticks: 1000  # Altitude tick interval in meters (for secondary y-axis for altitude (m))
+      rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
+      ts_select_time: 'time' #Time used for avg and plotting: Options: 'time' for UTC or 'time_local'
+      ts_avg_window: #'H' # pandas resample rule (e.g., 'H', 'D'). No averaging is done if ts_avg_window is null or not specified.
+      set_axis: False #If select True, add vmin_plot and vmax_plot for each variable in obs.
+      #vmin2, vmax2 filter not needed as filter_dict option added in 'altitude_yax2' to subset the paireddf as per altitude secondary-axis limits
+      #vmin2: #0  #Optional
+      #vmax2: #5000 #12000 #Optional #Subset limits for secondary y-axis (altitude_variable) 
+      altitude_yax2:
+        altitude_variable: altitude
+        altitude_ticks: 1000
+        ylabel2: Altitude (m)
+        plot_kwargs_y2:
+          color: g
+        altitude_unit: m
+        altitude_scaling_factor: 1
+        #filter_dict: #Default is min and max if filter_dict doesn't define the options below (or if they are commented out)
+        #  altitude:
+        #    oper: "between"
+        #    value: [2000,8000] # values are [vmin_y2, vmax_y2] 
+  plot_grp2:
+    type: 'vertprofile'  # plot type
+    fig_kwargs:  # Opt to define figure options
+      figsize: [10, 14]  # figure size
+    default_plot_kwargs:  # Opt to define defaults for all plots. Model kwargs overwrite these.
+      linewidth: 4.0
+      markersize: 10.
+    text_kwargs:  # Opt
+      fontsize: 18.
+    domain_type: ['all']  # List of domain types: 'all' or any domain in obs file. (e.g., airnow: epa_region, state_name, siteid, etc.)
+    domain_name: ['CONUS']  # List of domain names. If domain_type = all, domain_name is used in plot title.
+    data: ['firexaq_wrfchem_v4.2']  # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
+    data_proc:
+      rem_obs_nan: True  # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
+      set_axis: False  # If set to True, add vmin_plot and vmax_plot for each variable in obs.
+      interquartile_style: 'shading' # or 'box'
+    #TO DO: altitude_variable: 'Static_Pressure_YANG' or 'pressure_obs' (=P_BUI(hPa)*100) (pressure in Pa)  # ISSUE created: Add capability of the altitude variable to take pressure as an option to MSL height
+    altitude_variable: altitude #'MSL_GPS_Altitude_YANG' #'ALTITUDE' in m or desired unit
+    #vertprofile_bins: [0, 1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000]   # Specify the Pressure altitude bin size in hPa    
+    vertprofile_bins: [0, 1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000, 11000, 12000] # meters
+    #vertprofile_bins: [0, 1000, 2000, 3000, 4000, 5000] # meters # Needs to be specified as per min and max altitude (vmin, vmax)
+    vmin: #0  #Optional
+    vmax: #5000 # Optional #'vertprofile bins' need to be edited as per min and max altitude (i.e., vmin and vmax, if specified)
+
+  plot_grp3:
+    type: 'violin'
+    fig_kwargs:
+      figsize: [10, 8]
+    text_kwargs:
+      fontsize: 25.
+    domain_type: ['all']
+    domain_name: ['CONUS']
+    data: ['firexaq_wrfchem_v4.2']
+    data_proc:
+      rem_obs_nan: True 
+      set_axis: False
+
+    
+  plot_grp4:
+    type: 'scatter_density'
+    fig_kwargs:
+      figsize: [10, 10]
+    default_plot_kwargs:
+      linewidth: 4.0
+      markersize: 10.
+    text_kwargs:
+      fontsize: 18.
+    domain_type: ['all']
+    domain_name: ['CONUS']
+    data: ['firexaq_wrfchem_v4.2']
+    data_proc:
+      rem_obs_nan: True
+      set_axis: False #True
+      vmin_x: #0
+      vmax_x: #100
+      vmin_y: #0
+      vmax_y: #100
+    color_map: #'RdBu_r' # Default Colormap for the density plot can be used. Options include:
+                        # 'viridis', 'plasma', 'inferno', 'magma', 'cividis',
+                        # 'jet', 'hot', 'cool', 'spring', 'summer', 'autumn', 'winter',
+                        # 'RdBu_r', 'seismic', 'coolwarm',
+                        # 'Blues', 'BuGn', 'YlOrRd', 'Greys'
+        #To use a custom colormap: Use the following options otherwise use the above default color_map(s) AND COMMENT THESE
+        colors: ['royalblue', 'cyan', 'yellow', 'orange']
+        over: 'red'
+        under: 'blue'
+    xlabel: 'Model'
+    ylabel: 'Observation'
+    title: 'Scatter Density Plot'
+    fill: True #True #False              # Set to True if you want to fill the area under the density curve (for kde plot), False for sactterplot
+    shade_lowest: True #False      # Set to True if you want to shade the lowest contour (if fill=TRUE for KDE plots)
+    # Add other seaborn.kdeplot keyword arguments here as needed
+    vcenter: #0  # Central value for TwoSlopeNorm
+    extensions: ['min', 'max']  # Extensions for the colorbar  
+  plot_grp5:
+    type: 'taylor' # plot type
+    fig_kwargs: #Opt to define figure options
+      figsize: [8,8] # figure size if multiple plots
+    default_plot_kwargs: # Opt to define defaults for all plots. Model kwargs overwrite these.
+      linewidth: 2.0
+      markersize: 10.
+    text_kwargs: #Opt
+      fontsize: 16.
+    domain_type: ['all'] #List of domain types: 'all' or any domain in obs file. (e.g., airnow: epa_region, state_name, siteid, etc.) 
+    domain_name: ['CONUS'] #List of domain names. If domain_type = all domain_name is used in plot title.
+    data: ['firexaq_wrfchem_v4.2'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
+    data_proc:
+      rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
+      set_axis: True #If select True, add ty_scale for each variable in obs.
+  plot_grp6:
+    type: 'boxplot' # plot type
+    fig_kwargs: #Opt to define figure options
+      figsize: [8, 6] # figure size 
+    text_kwargs: #Opt
+      fontsize: 20.
+    domain_type: ['all'] #List of domain types: 'all' or any domain in obs file. (e.g., airnow: epa_region, state_name, siteid, etc.) 
+    domain_name: ['CONUS'] #List of domain names. If domain_type = all domain_name is used in plot title.
+    data: ['firexaq_wrfchem_v4.2'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
+    data_proc:
+      rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
+      set_axis: False #If select True, add vmin_plot and vmax_plot for each variable in obs.
+stats:
+  #Stats require positive numbers, so if you want to calculate temperature use Kelvin!
+  #Wind direction has special calculations for AirNow if obs name is 'WD'
+  stat_list: ['MB', 'MdnB','R2', 'RMSE'] #List stats to calculate. Dictionary of definitions included in plots/proc_stats.py Only stats listed below are currently working.
+  #Full calc list ['STDO', 'STDP', 'MdnNB','MdnNE','NMdnGE', 'NO','NOP','NP','MO','MP', 'MdnO', 'MdnP', 'RM', 'RMdn', 'MB', 'MdnB', 'NMB', 'NMdnB', 'FB', 'ME','MdnE','NME', 'NMdnE', 'FE', 'R2', 'RMSE','d1','E1', 'IOA', 'AC']
+  round_output: 2 #Opt, defaults to rounding to 3rd decimal place.
+  output_table: False #Always outputs a .txt file. Optional to also output as a table.
+  output_table_kwargs: #Opt 
+    figsize: [7, 3] # figure size 
+    fontsize: 12.
+    xscale: 1.4
+    yscale: 1.4
+    edges: 'horizontal'
+  domain_type: ['all'] #List of domain types: 'all' or any domain in obs file. (e.g., airnow: epa_region, state_name, siteid, etc.) 
+  domain_name: ['CONUS'] #List of domain names. If domain_type = all domain_name is used in plot title.
+  data: ['firexaq_wrfchem_v4.2'] # make this a list of pairs in obs_model where the obs is the obs label and model is the model_label
+
+

--- a/examples/yaml/control_wrfchem_aircraft_sumpmspecies.yaml
+++ b/examples/yaml/control_wrfchem_aircraft_sumpmspecies.yaml
@@ -10,8 +10,7 @@ analysis:
   debug: True
 model:
   wrfchem_v4.2: # model label
-    # files: /wrk/d2/rschwantes/wrf/firex_mech/qzhu/run_CONUS_fv19_BEIS_1.0xISO_RACM_v4.2.2_racm_berk_vcp_noI_phot_soa/0905/*
-    files: /wrk/users/charkins/melodies-monet_data/wrfchem/run_CONUS_fv19_BEIS_1.0xISO_RACM_v4.2.2_racm_berk_vcp_noI_phot_soa/0905/* #/scratch2/BMC/rcm1/qzhu/wrfchem/runs_firex/run_CONUS_fv19_BEIS_1.0xISO_RACM_v4.2.2_racm_vcp_noI_phot/Output/0905/* #/wrk/d2/rschwantes/wrf/firex_mech/qzhu/run_CONUS_fv19_BEIS_1.0xISO_RACM_v4.2.2_racm_berk_vcp_noI_phot_soa/0905/*
+    files: /wrk/d2/rschwantes/wrf/firex_mech/wrfchem_example/racm_esrl/*
     mod_type: 'wrfchem'
     mod_kwargs: 
       mech: 'racm_esrl_vcp'
@@ -89,8 +88,8 @@ obs:
         LLOD_setvalue: 0.0 # Opt Set LLOD_value=LLOD_setvalue, applied AFTER unit_scale and obs_unit
         ylabel_plot: 'Nitrate_PM1_AMS_JIMENEZ'
       'BC_mass_90_550_nm_SCHWARZ':
-        unit_scale: 1 #Opt Scaling factor 
-        unit_scale_method: '*' #Opt Multiply = '*' , Add = '+', subtract = '-', divide = '/'
+        unit_scale: 1000 #Opt Scaling factor 
+        unit_scale_method: '/' #Opt Multiply = '*' , Add = '+', subtract = '-', divide = '/'
         nan_value: -777777 # Opt Set this value to NaN
         LLOD_value: -888888 # Opt Set this value to LLOD_setvalue
         LLOD_setvalue: 0.0 # Opt Set LLOD_value=LLOD_setvalue, applied AFTER unit_scale and obs_unit

--- a/melodies_monet/driver.py
+++ b/melodies_monet/driver.py
@@ -535,9 +535,9 @@ class model:
         list_input_var = []
         for obs_map in self.mapping:
             if self.variable_summing is not None:
-                list_input_var = list_input_var + list(set(self.mapping[obs_map].keys()) - set(list_input_var))
-            else:
                 list_input_var = list_input_var + list(set(self.mapping[obs_map].keys()).union(set(vars_for_summing)) - set(self.variable_summing.keys()) - set(list_input_var) )
+            else:
+                list_input_var = list_input_var + list(set(self.mapping[obs_map].keys()) - set(list_input_var))
         #Only certain models need this option for speeding up i/o.
 
         if time_chunking_with_gridded_data:

--- a/melodies_monet/driver.py
+++ b/melodies_monet/driver.py
@@ -120,6 +120,7 @@ class observation:
         self.sat_type = None
         self.data_proc = None
         self.variable_dict = None
+        self.variable_summing = None
         self.resample = None
         self.time_var = None
 
@@ -203,6 +204,7 @@ class observation:
         self.add_coordinates_ground() # If ground site then add coordinates based on yaml if necessary
         self.mask_and_scale()  # mask and scale values from the control values
         self.rename_vars() # rename any variables as necessary 
+        self.sum_variables() 
         self.resample_data()
         self.filter_obs()
 
@@ -368,6 +370,31 @@ class observation:
                     # Then replace LLOD_value with LLOD_setvalue (after unit conversion)
                     if 'LLOD_value' in d:
                         self.obj[v].data = self.obj[v].where(self.obj[v] != d['LLOD_value'],d['LLOD_setvalue'])
+    
+    def sum_variables(self):
+        """Sum any variables noted that should be summed to create new variables.
+        This occurs after any unit scaling.
+
+        Returns
+        -------
+        None
+        """
+        
+        try:
+            if self.variable_summing is not None:
+                for var_new in self.variable_summing.keys():
+                    if var_new in self.obj.variables:
+                        print('The variable name, {}, already exists and cannot be created with variable_summing.'.format(var_new))
+                        raise ValueError
+                    var_new_info = self.variable_summing[var_new]
+                    self.variable_dict[var_new] = var_new_info
+                    for i,var in enumerate(var_new_info['vars']):
+                        if i ==0:
+                            self.obj[var_new] = self.obj[var].copy()
+                        else:
+                            self.obj[var_new] += self.obj[var]
+        except ValueError as e:
+            raise Exception("Something happened when using variable_summing:") from e
 
     def resample_data(self):
         """Resample the obs df based on the value set in the control file.
@@ -417,6 +444,7 @@ class model:
         self.obj = None
         self.mapping = None
         self.variable_dict = None
+        self.variable_summing = None
         self.plot_kwargs = None
         self.proj = None
 
@@ -499,9 +527,14 @@ class model:
         self.glob_files()
         # Calculate species to input into MONET, so works for all mechanisms in wrfchem
         # I want to expand this for the other models too when add aircraft data.
+        # First make a list of variables not in mapping but from variable_summing, if provided
+        vars_for_summing  = []
+        if self.variable_summing is not None:
+            for var in self.variable_summing.keys():
+                vars_for_summing= vars_for_summing + self.variable_summing[var]['vars']
         list_input_var = []
         for obs_map in self.mapping:
-            list_input_var = list_input_var + list(set(self.mapping[obs_map].keys()) - set(list_input_var))
+            list_input_var = list_input_var + list(set(self.mapping[obs_map].keys()).union(set(vars_for_summing)) - set(self.variable_summing.keys()) - set(list_input_var) )
         #Only certain models need this option for speeding up i/o.
 
         if time_chunking_with_gridded_data:
@@ -567,6 +600,7 @@ class model:
                     self.obj = xr.open_dataset(self.files[0],**self.mod_kwargs)
         self.mask_and_scale()
         self.rename_vars() # rename any variables as necessary 
+        self.sum_variables()
 
     def rename_vars(self):
         """Rename any variables in model with rename set.
@@ -613,6 +647,30 @@ class model:
                         print('changing units for {}'.format(v))
                         self.obj[v].values *= 1e9
                         self.obj[v].attrs['units'] = 'ppbv'        
+    def sum_variables(self):
+        """Sum any variables noted that should be summed to create new variables.
+        This occurs after any unit scaling.
+
+        Returns
+        -------
+        None
+        """
+        
+        try:
+            if self.variable_summing is not None:
+                for var_new in self.variable_summing.keys():
+                    if var_new in self.obj.variables:
+                        print('The variable name, {}, already exists and cannot be created with variable_summing.'.format(var_new))
+                        raise ValueError
+                    var_new_info = self.variable_summing[var_new]
+                    self.variable_dict[var_new] = var_new_info
+                    for i,var in enumerate(var_new_info['vars']):
+                        if i ==0:
+                            self.obj[var_new] = self.obj[var].copy()
+                        else:
+                            self.obj[var_new] += self.obj[var]
+        except ValueError as e:
+            raise Exception("Something happened when using variable_summing:") from e
 
 class analysis:
     """The analysis class.
@@ -870,6 +928,8 @@ class analysis:
 
                 if 'variables' in self.control_dict['model'][mod].keys():
                     m.variable_dict = self.control_dict['model'][mod]['variables']
+                if 'variable_summing' in self.control_dict['model'][mod].keys():
+                    m.variable_summing = self.control_dict['model'][mod]['variable_summing']
                 if 'plot_kwargs' in self.control_dict['model'][mod].keys():
                     m.plot_kwargs = self.control_dict['model'][mod]['plot_kwargs']
                     
@@ -944,6 +1004,8 @@ class analysis:
                     o.debug = self.control_dict['obs'][obs]['debug']
                 if 'variables' in self.control_dict['obs'][obs].keys():
                     o.variable_dict = self.control_dict['obs'][obs]['variables']
+                if 'variable_summing' in self.control_dict['obs'][obs].keys():
+                    o.variable_summing = self.control_dict['obs'][obs]['variable_summing']
                 if 'resample' in self.control_dict['obs'][obs].keys():
                     o.resample = self.control_dict['obs'][obs]['resample']
                 if 'time_var' in self.control_dict['obs'][obs].keys():

--- a/melodies_monet/driver.py
+++ b/melodies_monet/driver.py
@@ -528,13 +528,16 @@ class model:
         # Calculate species to input into MONET, so works for all mechanisms in wrfchem
         # I want to expand this for the other models too when add aircraft data.
         # First make a list of variables not in mapping but from variable_summing, if provided
-        vars_for_summing  = []
         if self.variable_summing is not None:
+            vars_for_summing  = []
             for var in self.variable_summing.keys():
                 vars_for_summing= vars_for_summing + self.variable_summing[var]['vars']
         list_input_var = []
         for obs_map in self.mapping:
-            list_input_var = list_input_var + list(set(self.mapping[obs_map].keys()).union(set(vars_for_summing)) - set(self.variable_summing.keys()) - set(list_input_var) )
+            if self.variable_summing is not None:
+                list_input_var = list_input_var + list(set(self.mapping[obs_map].keys()) - set(list_input_var))
+            else:
+                list_input_var = list_input_var + list(set(self.mapping[obs_map].keys()).union(set(vars_for_summing)) - set(self.variable_summing.keys()) - set(list_input_var) )
         #Only certain models need this option for speeding up i/o.
 
         if time_chunking_with_gridded_data:

--- a/melodies_monet/util/tools.py
+++ b/melodies_monet/util/tools.py
@@ -458,3 +458,44 @@ def loop_pairing(control,file_pairs_yaml='',file_pairs={},save_types=['paired'])
         an.pair_data()
         an.save_analysis()
 
+def convert_std_to_amb_ams(ds,convert_vars=[],temp_var=None,pres_var=None):
+    
+    # Convert variables from std to amb
+    
+    # Units of temp_var must be K
+    # Units of pres_var must be Pa 
+    
+    #So I just need to convert the obs from std to amb.
+    Losch = 2.69e25 # loschmidt's number
+    #I checked the more detailed icart files
+    #273 K, 1 ATM (101325 Pa)
+    std_ams = 101325.*6.02214e23/(8.314472*273.)
+    #use pressure_obs now, which is in pa
+    Airnum = ds[pres_var]*6.02214e23/(8.314472*ds[temp_var])
+    
+    # amb to std = Losch / Airnum
+    convert_std_to_amb_ams = Airnum/std_ams
+    
+    for var in convert_vars:
+        ds[var] = ds[var]*convert_std_to_amb_ams
+
+def convert_std_to_amb_bc(ds,convert_vars=[],temp_var=None,pres_var=None):
+    
+    # Convert variables from std to amb
+    
+    # Units of temp_var must be K
+    # Units of pres_var must be Pa 
+    
+    #So I just need to convert the obs from std to amb.
+    Losch = 2.69e25 # loschmidt's number
+    #1013 mb, 273 K (101300 Pa)
+    std_bc = 101300.*6.02214e23/(8.314472*273.)
+    #use pressure_obs now, which is in pa
+    Airnum = ds[pres_var]*6.02214e23/(8.314472*ds[temp_var])
+    
+    # amb to std = Losch / Airnum
+    convert_std_to_amb_bc = Airnum/std_bc
+    
+    for var in convert_vars:
+        ds[var] = ds[var]*convert_std_to_amb_bc
+


### PR DESCRIPTION
This pull request adds the functionality for summing up variables into a new variable for models and obs. An example of how this is used is that model PM variables may need to be summed when comparing to observational variables for PM. 

Additionally, this pull requests adds functions for some of the unit conversions between std and amb needed to compare with variables in firexaq.

This is developed based on the code attached below.

[analysis_LA_both_aerosols_vert_mix_v422_phot.txt](https://github.com/NOAA-CSL/MELODIES-MONET/files/14781987/analysis_LA_both_aerosols_vert_mix_v422_phot.txt)
