### PR TITLE
Add numeric_only=True to relevant pandas operations

### DIFF
--- a/docs/develop/developers_guide.rst
+++ b/docs/develop/developers_guide.rst
@@ -74,7 +74,7 @@ these instructions:
 
        $ conda create --name melodies-monet python=3.9
        $ conda activate melodies-monet
-       $ conda install -y -c conda-forge pyyaml pandas=1 monet monetio netcdf4 wrf-python typer rich pooch jupyterlab
+       $ conda install -y -c conda-forge pyyaml pandas=1 'matplotlib-base<3.9' monet monetio netcdf4 wrf-python typer rich pooch jupyterlab
 
 (b) Clone [#clone]_ and link the latest development versions of MONET and MONETIO from GitHub to
     your conda environment::

--- a/docs/environment-docs.yml
+++ b/docs/environment-docs.yml
@@ -7,6 +7,7 @@ dependencies:
   - python=3.9
   #
   # melodies_monet deps
+  - matplotlib-base<3.9  # for pandas v1 compat
   - monet
   - monetio
   - netcdf4

--- a/docs/examples/control_camchem.yaml
+++ b/docs/examples/control_camchem.yaml
@@ -86,7 +86,7 @@ plots:
     data_proc:
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       ts_select_time: 'time' # Time used for avg and plotting: Options: 'time' for UTC or 'time_local'
-      ts_avg_window: 'H' # Options: None for no averaging or list pandas resample rule (e.g., 'H', 'D')
+      ts_avg_window: 'h' # Options: None for no averaging or list pandas resample rule (e.g., 'h', 'D')
       set_axis: False # If select True, add vmin_plot and vmax_plot for each variable in obs.
   plot_grp2:
     type: 'taylor' # plot type

--- a/docs/examples/control_camchem_se.yaml
+++ b/docs/examples/control_camchem_se.yaml
@@ -86,7 +86,7 @@ plots:
     data_proc:
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       ts_select_time: 'time_local' #Time used for avg and plotting: Options: 'time' for UTC or 'time_local'
-      ts_avg_window: 'H' # Options: None for no averaging or list pandas resample rule (e.g., 'H', 'D')
+      ts_avg_window: 'h' # Options: None for no averaging or list pandas resample rule (e.g., 'h', 'D')
       set_axis: False #If select True, add vmin_plot and vmax_plot for each variable in obs.
   plot_grp2:
     type: 'taylor' # plot type

--- a/docs/examples/control_idealized.yaml
+++ b/docs/examples/control_idealized.yaml
@@ -61,7 +61,7 @@ plots:
     data_proc:  # These four seem to be required for time series
       rem_obs_nan: True  # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       ts_select_time: 'time'  # 'time' for UTC or 'time_local'
-      ts_avg_window: '3H'  # Options: None for no averaging or list pandas resample rule (e.g., 'H', 'D')
+      ts_avg_window: '3h'  # Options: None for no averaging or list pandas resample rule (e.g., 'h', 'D')
       # ^ TODO: null setting seems not working
       set_axis: False  # If True, add vmin_plot and vmax_plot for each variable in obs.
 

--- a/docs/examples/control_wrfchem_mech-0905_2.yaml
+++ b/docs/examples/control_wrfchem_mech-0905_2.yaml
@@ -126,8 +126,8 @@ plots:
       ts_select_time: "time_local"  # `ts_` indicates this is time series plot-specific
       # ^ Time used for avg and plotting
       #   Options: 'time' for UTC or 'time_local'
-      ts_avg_window: "H"
-      # ^ Options: None for no averaging, pandas resample rule (e.g., 'H', 'D')
+      ts_avg_window: "h"
+      # ^ Options: None for no averaging, pandas resample rule (e.g., 'h', 'D')
       set_axis: True
       # ^ If true, add `vmin_plot` and `vmax_plot` for each variable in obs.
 

--- a/docs/examples/control_wrfchem_saveandread.yaml
+++ b/docs/examples/control_wrfchem_saveandread.yaml
@@ -147,8 +147,8 @@ plots:
       ts_select_time: "time_local"  # `ts_` indicates this is time series plot-specific
       # ^ Time used for avg and plotting
       #   Options: 'time' for UTC or 'time_local'
-      ts_avg_window: "H"
-      # ^ Options: None for no averaging, pandas resample rule (e.g., 'H', 'D')
+      ts_avg_window: "h"
+      # ^ Options: None for no averaging, pandas resample rule (e.g., 'h', 'D')
       set_axis: True
       # ^ If true, add `vmin_plot` and `vmax_plot` for each variable in obs.
 

--- a/docs/tutorial/installation.rst
+++ b/docs/tutorial/installation.rst
@@ -34,7 +34,7 @@ First create and activate a conda environment::
 
 Add dependencies from conda-forge::
 
-    $ conda install -y -c conda-forge pyyaml pandas=1 monet monetio netcdf4 wrf-python typer rich pooch
+    $ conda install -y -c conda-forge pyyaml pandas=1 'matplotlib-base<3.9' monet monetio netcdf4 wrf-python typer rich pooch
 
 Now, install the stable branch of MELODIES MONET to the environment::
 

--- a/examples/forecast_evaluation/reformat_aeronet_rapchemtest.py
+++ b/examples/forecast_evaluation/reformat_aeronet_rapchemtest.py
@@ -15,16 +15,16 @@ start_time_reformat=sys.argv[1]
 end_time_reformat=sys.argv[2]
 print(sys.argv[1])
 print(sys.argv[2])
-dates = pd.date_range(start=start_time_reformat,end=end_time_reformat,freq='H')
+dates = pd.date_range(start=start_time_reformat,end=end_time_reformat,freq='h')
 
-#dates = pd.date_range(start='2021-08-01',end='2021-09-01',freq='H')
+#dates = pd.date_range(start='2021-08-01',end='2021-09-01',freq='h')
 # set the output filename
 #outname = 'AERONET_L15_20190901_20190930.nc'
 outname = 'test5.nc'
 # set standard wavelengths
 standard_wavelengths = np.array([0.34, 0.44, 0.55, 0.66, 0.86, 1.63, 11.1])* 1000. # convert from micron to nm
 # get the data
-df = mio.aeronet.add_data(dates, interp_to_aod_values=standard_wavelengths, freq='H') # ,n_procs=12)
+df = mio.aeronet.add_data(dates, interp_to_aod_values=standard_wavelengths, freq='h') # ,n_procs=12)
 
 
 # dfp = df.rename({'siteid':'x'},axis=1).set_index(['time','x']).drop_duplicates()

--- a/examples/forecast_evaluation/reformat_airnow_rapchemtest.py
+++ b/examples/forecast_evaluation/reformat_airnow_rapchemtest.py
@@ -16,8 +16,8 @@ start_time_reformat=sys.argv[1]
 end_time_reformat=sys.argv[2] 
 print(sys.argv[1])
 print(sys.argv[2])
-dates = pd.date_range(start=start_time_reformat,end=end_time_reformat,freq='H')
-#dates = pd.date_range(start='2021-05-28',end='2021-05-29',freq='H')
+dates = pd.date_range(start=start_time_reformat,end=end_time_reformat,freq='h')
+#dates = pd.date_range(start='2021-05-28',end='2021-05-29',freq='h')
 
 
 # helper function for local time.  Could be important for EPA statistics\n"
@@ -28,7 +28,7 @@ def get_local_time(ds):
         o = tim.expand_dims({'x':t.x.values}).transpose('time','x')
         on = xr.Dataset({'time_local':o,'utcoffset':t.utcoffset})
         y = on.to_dataframe()
-        y['time_local'] = y.time_local + pd.to_timedelta(y.utcoffset, unit='H')
+        y['time_local'] = y.time_local + pd.to_timedelta(y.utcoffset, unit='h')
         time_local = y[['time_local']].to_xarray()
         ds = xr.merge([ds,time_local])
     return ds

--- a/examples/subset/airnow_wrfchem.yaml
+++ b/examples/subset/airnow_wrfchem.yaml
@@ -82,7 +82,7 @@ plots:
     data_proc:
       rem_obs_nan: True
       ts_select_time: 'time_local'
-      ts_avg_window: 'H'
+      ts_avg_window: 'h'
       set_axis: True
 
   plot_overlay_group:

--- a/examples/yaml/control_cmaq-rrfs_surface-all-short_test_jupyter.yaml
+++ b/examples/yaml/control_cmaq-rrfs_surface-all-short_test_jupyter.yaml
@@ -163,7 +163,7 @@ plots:
       #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       ts_select_time: 'time_local' #Time used for avg and plotting: Options: 'time' for UTC or 'time_local'
-      ts_avg_window: 'H' # pandas resample rule (e.g., 'H', 'D'). No averaging is done if ts_avg_window is null or not specified.
+      ts_avg_window: 'h' # pandas resample rule (e.g., 'h', 'D'). No averaging is done if ts_avg_window is null or not specified.
       set_axis: False #If select True, add vmin_plot and vmax_plot for each variable in obs.
   plot_grp2:
     type: 'taylor' # plot type

--- a/examples/yaml/control_cmaq-rrfs_surface-all.yaml
+++ b/examples/yaml/control_cmaq-rrfs_surface-all.yaml
@@ -163,7 +163,7 @@ plots:
       #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       ts_select_time: 'time_local' #Time used for avg and plotting: Options: 'time' for UTC or 'time_local'
-      ts_avg_window: 'H' # pandas resample rule (e.g., 'H', 'D'). No averaging is done if ts_avg_window is null or not specified.
+      ts_avg_window: 'h' # pandas resample rule (e.g., 'h', 'D'). No averaging is done if ts_avg_window is null or not specified.
       set_axis: False #If select True, add vmin_plot and vmax_plot for each variable in obs.
   plot_grp2:
     type: 'taylor' # plot type

--- a/examples/yaml/control_cmaq-rrfs_surface.yaml
+++ b/examples/yaml/control_cmaq-rrfs_surface.yaml
@@ -201,7 +201,7 @@ plots:
       #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       ts_select_time: 'time_local' #Time used for avg and plotting: Options: 'time' for UTC or 'time_local'
-      ts_avg_window: 'H' # pandas resample rule (e.g., 'H', 'D'). No averaging is done if ts_avg_window is null or not specified.
+      ts_avg_window: 'h' # pandas resample rule (e.g., 'h', 'D'). No averaging is done if ts_avg_window is null or not specified.
       set_axis: False #If select True, add vmin_plot and vmax_plot for each variable in obs.
   plot_grp2:
     type: 'taylor' # plot type

--- a/examples/yaml/control_cmaq.yaml
+++ b/examples/yaml/control_cmaq.yaml
@@ -155,7 +155,7 @@ plots:
       #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       ts_select_time: 'time_local' #Time used for avg and plotting: Options: 'time' for UTC or 'time_local'
-      ts_avg_window: 'H' # pandas resample rule (e.g., 'H', 'D'). No averaging is done if ts_avg_window is null or not specified.
+      ts_avg_window: 'h' # pandas resample rule (e.g., 'h', 'D'). No averaging is done if ts_avg_window is null or not specified.
       set_axis: False #If select True, add vmin_plot and vmax_plot for each variable in obs.
   plot_grp2:
     type: 'taylor' # plot type

--- a/examples/yaml/control_hrrr-smoke_mobile.yaml
+++ b/examples/yaml/control_hrrr-smoke_mobile.yaml
@@ -60,7 +60,7 @@ plots:
     data_proc:
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       ts_select_time: 'time' #Time used for avg and plotting: Options: 'time' for UTC or 'time_local'
-      ts_avg_window: null # Options: None for no averaging or list pandas resample rule (e.g., 'H', 'D')
+      ts_avg_window: null # Options: None for no averaging or list pandas resample rule (e.g., 'h', 'D')
       set_axis: False #If select True, add vmin_plot and vmax_plot for each variable in obs.
   plot_grp2:
     type: 'taylor' # plot type

--- a/examples/yaml/control_omps_limb.yaml
+++ b/examples/yaml/control_omps_limb.yaml
@@ -48,7 +48,7 @@ plots:
     data_proc:
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       ts_select_time: 'time_local' #Time used for avg and plotting: Options: 'time' for UTC or 'time_local'
-      ts_avg_window: 'H' # Options: None for no averaging or list pandas resample rule (e.g., 'H', 'D')
+      ts_avg_window: 'h' # Options: None for no averaging or list pandas resample rule (e.g., 'h', 'D')
       set_axis: False #If select True, add vmin_plot and vmax_plot for each variable in obs.
   plot_grp2:
     type: 'taylor' # plot type

--- a/examples/yaml/control_omps_nm-raqms.yaml
+++ b/examples/yaml/control_omps_nm-raqms.yaml
@@ -54,7 +54,7 @@ plots:
 #    data_proc:
 #      rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
 #      ts_select_time: 'time' #Time used for avg and plotting: Options: 'time' for UTC or 'time_local'
-#      ts_avg_window: 'min' # Options: None for no averaging or list pandas resample rule (e.g., 'H', 'D')
+#      ts_avg_window: 'min' # Options: None for no averaging or list pandas resample rule (e.g., 'h', 'D')
 #      set_axis: False #If select True, add vmin_plot and vmax_plot for each variable in obs.
   plot_grp2:
     type: 'taylor' # plot type

--- a/examples/yaml/control_read_looped_aircraft.yaml
+++ b/examples/yaml/control_read_looped_aircraft.yaml
@@ -117,7 +117,7 @@ plots:
       #altitude_ticks: 1000  # Altitude tick interval in meters (for secondary y-axis for altitude (m))
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       ts_select_time: 'time' #Time used for avg and plotting: Options: 'time' for UTC or 'time_local'
-      ts_avg_window: #'H' # pandas resample rule (e.g., 'H', 'D'). No averaging is done if ts_avg_window is null or not specified.
+      ts_avg_window: #'h' # pandas resample rule (e.g., 'h', 'D'). No averaging is done if ts_avg_window is null or not specified.
       set_axis: False #If select True, add vmin_plot and vmax_plot for each variable in obs.
       #vmin2, vmax2 filter not needed as filter_dict option added in 'altitude_yax2' to subset the paireddf as per altitude secondary-axis limits
       #vmin2: #0  #Optional

--- a/examples/yaml/control_rrfs_cmaq_airnow_norm.yaml
+++ b/examples/yaml/control_rrfs_cmaq_airnow_norm.yaml
@@ -167,7 +167,7 @@ plots:
       #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       ts_select_time: 'time_local' #Time used for avg and plotting: Options: 'time' for UTC or 'time_local'
-      ts_avg_window: 'H' # pandas resample rule (e.g., 'H', 'D'). No averaging is done if ts_avg_window is null or not specified.
+      ts_avg_window: 'h' # pandas resample rule (e.g., 'h', 'D'). No averaging is done if ts_avg_window is null or not specified.
       set_axis: False #If select True, add vmin_plot and vmax_plot for each variable in obs.
   plot_grp2:
     type: 'taylor' # plot type

--- a/examples/yaml/control_rrfs_cmaq_airnow_reg.yaml
+++ b/examples/yaml/control_rrfs_cmaq_airnow_reg.yaml
@@ -167,7 +167,7 @@ plots:
       #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       ts_select_time: 'time_local' #Time used for avg and plotting: Options: 'time' for UTC or 'time_local'
-      ts_avg_window: 'D' # pandas resample rule (e.g., 'H', 'D'). No averaging is done if ts_avg_window is null or not specified.
+      ts_avg_window: 'D' # pandas resample rule (e.g., 'h', 'D'). No averaging is done if ts_avg_window is null or not specified.
       set_axis: False #If select True, add vmin_plot and vmax_plot for each variable in obs.
   plot_grp2:
     type: 'taylor' # plot type

--- a/examples/yaml/control_wrfchem.yaml
+++ b/examples/yaml/control_wrfchem.yaml
@@ -117,7 +117,7 @@ plots:
       #rem_obs_by_nan_pct: {'group_var': 'siteid','pct_cutoff': 25,'times':'hourly'} # Groups by group_var, then removes all instances of groupvar where obs variable is > pct_cutoff % nan values
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       ts_select_time: 'time_local' #Time used for avg and plotting: Options: 'time' for UTC or 'time_local'
-      ts_avg_window: 'H' # pandas resample rule (e.g., 'H', 'D'). No averaging is done if ts_avg_window is null or not specified.
+      ts_avg_window: 'h' # pandas resample rule (e.g., 'h', 'D'). No averaging is done if ts_avg_window is null or not specified.
       set_axis: False #If select True, add vmin_plot and vmax_plot for each variable in obs.
   plot_grp2:
     type: 'taylor' # plot type

--- a/examples/yaml/control_wrfchem_aircraft.yaml
+++ b/examples/yaml/control_wrfchem_aircraft.yaml
@@ -99,7 +99,7 @@ plots:
     data_proc:
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       ts_select_time: 'time' #Time used for avg and plotting: Options: 'time' for UTC or 'time_local'
-      ts_avg_window: 'H' # Options: None for no averaging or list pandas resample rule (e.g., 'H', 'D')
+      ts_avg_window: 'h' # Options: None for no averaging or list pandas resample rule (e.g., 'h', 'D')
       set_axis: False #If select True, add vmin_plot and vmax_plot for each variable in obs.
   plot_grp2:
     type: 'taylor' # plot type

--- a/examples/yaml/control_wrfchem_aircraft_Latestfor_develop_aircraft.yaml
+++ b/examples/yaml/control_wrfchem_aircraft_Latestfor_develop_aircraft.yaml
@@ -107,7 +107,7 @@ plots:
       #altitude_ticks: 1000  # Altitude tick interval in meters (for secondary y-axis for altitude (m))
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       ts_select_time: 'time' #Time used for avg and plotting: Options: 'time' for UTC or 'time_local'
-      ts_avg_window: #'H' # pandas resample rule (e.g., 'H', 'D'). No averaging is done if ts_avg_window is null or not specified.
+      ts_avg_window: #'h' # pandas resample rule (e.g., 'h', 'D'). No averaging is done if ts_avg_window is null or not specified.
       set_axis: False #If select True, add vmin_plot and vmax_plot for each variable in obs.
       #vmin2, vmax2 filter not needed as filter_dict option added in 'altitude_yax2' to subset the paireddf as per altitude secondary-axis limits
       #vmin2: #0  #Optional

--- a/examples/yaml/control_wrfchem_aircraft_Latestfor_develop_aircraft_testmultiplemodelgroups.yaml
+++ b/examples/yaml/control_wrfchem_aircraft_Latestfor_develop_aircraft_testmultiplemodelgroups.yaml
@@ -144,7 +144,7 @@ plots:
       #altitude_ticks: 1000  # Altitude tick interval in meters (for secondary y-axis for altitude (m))
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       ts_select_time: 'time' #Time used for avg and plotting: Options: 'time' for UTC or 'time_local'
-      ts_avg_window: #'H' # pandas resample rule (e.g., 'H', 'D'). No averaging is done if ts_avg_window is null or not specified.
+      ts_avg_window: #'h' # pandas resample rule (e.g., 'h', 'D'). No averaging is done if ts_avg_window is null or not specified.
       set_axis: False #If select True, add vmin_plot and vmax_plot for each variable in obs.
       #vmin2, vmax2 filter not needed as filter_dict option added in 'altitude_yax2' to subset the paireddf as per altitude secondary-axis limits
       #vmin2: #0  #Optional

--- a/examples/yaml/control_wrfchem_ground.yaml
+++ b/examples/yaml/control_wrfchem_ground.yaml
@@ -49,7 +49,7 @@ plots:
     data_proc:
       rem_obs_nan: True # True: Remove all points where model or obs variable is NaN. False: Remove only points where model variable is NaN.
       ts_select_time: 'time' #Time used for avg and plotting: Options: 'time' for UTC or 'time_local'
-      ts_avg_window: 'H' # Options: None for no averaging or list pandas resample rule (e.g., 'H', 'D')
+      ts_avg_window: 'h' # Options: None for no averaging or list pandas resample rule (e.g., 'h', 'D')
       set_axis: False #If select True, add vmin_plot and vmax_plot for each variable in obs.
   plot_grp2:
     type: 'taylor' # plot type

--- a/melodies_monet/_cli.py
+++ b/melodies_monet/_cli.py
@@ -186,7 +186,7 @@ def get_aeronet(
     start_date: str = typer.Option(..., "-s", "--start-date", help=f"Start date. {_DATE_FMT_NOTE}"),
     end_date: str = typer.Option(..., "-e", "--end-date", help=f"End date. {_DATE_FMT_NOTE} {_DATE_END_NOTE}"),
     daily: bool = typer.Option(False, help="Whether to retrieve the daily averaged data product."),
-    freq: str = typer.Option("H", "-f", "--freq", help=(
+    freq: str = typer.Option("h", "-f", "--freq", help=(
             "Frequency to resample to. "
             "Mean is used to reduce the time groups (as opposed to nearest, e.g.)."
         )
@@ -368,7 +368,7 @@ def get_airnow(
 
     start_date = pd.Timestamp(start_date)
     end_date = pd.Timestamp(end_date)
-    dates = pd.date_range(start_date, end_date, freq="H" if not daily else "D")
+    dates = pd.date_range(start_date, end_date, freq="h" if not daily else "D")
     if verbose:
         print("Dates:")
         print(dates)
@@ -555,7 +555,7 @@ def get_ish_lite(
 
     start_date = pd.Timestamp(start_date)
     end_date = pd.Timestamp(end_date)
-    dates = pd.date_range(start_date, end_date, freq="H")
+    dates = pd.date_range(start_date, end_date, freq="h")
     if verbose:
         print("Dates:")
         print(dates)
@@ -700,7 +700,7 @@ def get_ish_lite(
 def get_ish(
     start_date: str = typer.Option(..., "-s", "--start-date", help=f"Start date. {_DATE_FMT_NOTE}"),
     end_date: str = typer.Option(..., "-e", "--end-date", help=f"End date. {_DATE_FMT_NOTE} {_DATE_END_NOTE}"),
-    freq: str = typer.Option("H", "-f", "--freq", help=(
+    freq: str = typer.Option("h", "-f", "--freq", help=(
             "Frequency to resample to. "
             "Mean is used to reduce the time groups (as opposed to nearest, e.g.)."
         )
@@ -771,7 +771,7 @@ def get_ish(
 
     start_date = pd.Timestamp(start_date)
     end_date = pd.Timestamp(end_date)
-    dates = pd.date_range(start_date, end_date, freq="H")
+    dates = pd.date_range(start_date, end_date, freq="h")
     if verbose:
         print("Dates:")
         print(dates)
@@ -982,7 +982,7 @@ def get_aqs(
 
     start_date = pd.Timestamp(start_date)
     end_date = pd.Timestamp(end_date)
-    dates = pd.date_range(start_date, end_date, freq="H" if not daily else "D")
+    dates = pd.date_range(start_date, end_date, freq="h" if not daily else "D")
     if verbose:
         print("Dates:")
         print(dates)

--- a/melodies_monet/driver.py
+++ b/melodies_monet/driver.py
@@ -1463,7 +1463,7 @@ class analysis:
                             df2 = (
                                 pairdf.copy()
                                 .groupby("siteid")
-                                .resample('H', on='time_local')
+                                .resample('h', on='time_local')
                                 .mean()
                                 .reset_index()
                             )
@@ -2358,7 +2358,7 @@ class analysis:
                             df2 = (
                                 pairdf.copy()
                                 .groupby("siteid")
-                                .resample('H', on='time_local')
+                                .resample('h', on='time_local')
                                 .mean()
                                 .reset_index()
                             )

--- a/melodies_monet/plots/aircraftplots.py
+++ b/melodies_monet/plots/aircraftplots.py
@@ -117,9 +117,9 @@ def make_spatial_bias(df, df_reg=None, column_o=None, label_o=None, column_m=Non
     if df_reg is not None:
         # JianHe: include options for percentile calculation (set in yaml file)
         if ptile is None:
-            df_mean=df_reg.groupby(['siteid'],as_index=False).mean()
+            df_mean=df_reg.groupby(['siteid'],as_index=False).mean(numeric_only=True)
         else:
-            df_mean=df_reg.groupby(['siteid'],as_index=False).quantile(ptile/100.)
+            df_mean=df_reg.groupby(['siteid'],as_index=False).quantile(ptile/100., numeric_only=True)
 
         #Specify val_max = vdiff. the sp_scatter_bias plot in MONET only uses the val_max value
         #and then uses -1*val_max value for the minimum.
@@ -129,9 +129,9 @@ def make_spatial_bias(df, df_reg=None, column_o=None, label_o=None, column_m=Non
     else:
         # JianHe: include options for percentile calculation (set in yaml file)
         if ptile is None:
-            df_mean=df.groupby(['siteid'],as_index=False).mean()
+            df_mean=df.groupby(['siteid'],as_index=False).mean(numeric_only=True)
         else:
-            df_mean=df.groupby(['siteid'],as_index=False).quantile(ptile/100.)
+            df_mean=df.groupby(['siteid'],as_index=False).quantile(ptile/100., numeric_only=True)
        
         #Specify val_max = vdiff. the sp_scatter_bias plot in MONET only uses the val_max value
         #and then uses -1*val_max value for the minimum.
@@ -315,19 +315,19 @@ def make_vertprofile(df, column=None, label=None, ax=None, bins=None, altitude_v
         bin_midpoints = altitude_bins.apply(lambda x: x.mid)
         # Convert bin_midpoints to a column in the DataFrame
         df['bin_midpoints'] = bin_midpoints
-        median = df.groupby(altitude_bins, observed=True)[column].median()
-        q1 = df.groupby(altitude_bins, observed=True)[column].quantile(0.25)
-        q3 = df.groupby(altitude_bins, observed=True)[column].quantile(0.75)
+        median = df.groupby(altitude_bins, observed=True)[column].median(numeric_only=True)
+        q1 = df.groupby(altitude_bins, observed=True)[column].quantile(0.25, numeric_only=True)
+        q3 = df.groupby(altitude_bins, observed=True)[column].quantile(0.75, numeric_only=True)
         # Convert bin_midpoints to a numerical data type
         df['bin_midpoints'] = df['bin_midpoints'].astype(float)
 
-        p5 = df.groupby(altitude_bins, observed=True)[column].quantile(0.05)
-        p10 = df.groupby(altitude_bins, observed=True)[column].quantile(0.10)
-        p90 = df.groupby(altitude_bins, observed=True)[column].quantile(0.90)
-        p95 = df.groupby(altitude_bins, observed=True)[column].quantile(0.95)
+        p5 = df.groupby(altitude_bins, observed=True)[column].quantile(0.05, numeric_only=True)
+        p10 = df.groupby(altitude_bins, observed=True)[column].quantile(0.10, numeric_only=True)
+        p90 = df.groupby(altitude_bins, observed=True)[column].quantile(0.90, numeric_only=True)
+        p95 = df.groupby(altitude_bins, observed=True)[column].quantile(0.95, numeric_only=True)
         
         # Calculate the mean of bin_midpoints grouped by altitude bins
-        binmidpoint = df.groupby(altitude_bins, observed=True)['bin_midpoints'].mean()
+        binmidpoint = df.groupby(altitude_bins, observed=True)['bin_midpoints'].mean(numeric_only=True)
 
         ##Plotting vertprofile starts
         plot_kwargs_fillbetween = plot_kwargs.copy()
@@ -420,20 +420,20 @@ def make_vertprofile(df, column=None, label=None, ax=None, bins=None, altitude_v
         # Convert bin_midpoints to a column in the DataFrame
         df['bin_midpoints'] = bin_midpoints
         # can be .groupby(bin_midpoints) as well (qzr)
-        median = df.groupby(altitude_bins, observed=True)[column].median()
-        q1 = df.groupby(altitude_bins, observed=True)[column].quantile(0.25)
-        q3 = df.groupby(altitude_bins, observed=True)[column].quantile(0.75)
+        median = df.groupby(altitude_bins, observed=True)[column].median(numeric_only=True)
+        q1 = df.groupby(altitude_bins, observed=True)[column].quantile(0.25, numeric_only=True)
+        q3 = df.groupby(altitude_bins, observed=True)[column].quantile(0.75, numeric_only=True)
         # Convert bin_midpoints to a numerical data type
         df['bin_midpoints'] = df['bin_midpoints'].astype(float)
 
         # Calculate the 10th, 90th, 5th, and 95th percentiles
-        p10 = df.groupby(altitude_bins, observed=True)[column].quantile(0.10)
-        p90 = df.groupby(altitude_bins, observed=True)[column].quantile(0.90)
-        p5 = df.groupby(altitude_bins, observed=True)[column].quantile(0.05)
-        p95 = df.groupby(altitude_bins, observed=True)[column].quantile(0.95)
+        p10 = df.groupby(altitude_bins, observed=True)[column].quantile(0.10, numeric_only=True)
+        p90 = df.groupby(altitude_bins, observed=True)[column].quantile(0.90, numeric_only=True)
+        p5 = df.groupby(altitude_bins, observed=True)[column].quantile(0.05, numeric_only=True)
+        p95 = df.groupby(altitude_bins, observed=True)[column].quantile(0.95, numeric_only=True)
 
         # Calculate the mean of bin_midpoints grouped by altitude bins
-        binmidpoint = df.groupby(altitude_bins, observed=True)['bin_midpoints'].mean()
+        binmidpoint = df.groupby(altitude_bins, observed=True)['bin_midpoints'].mean(numeric_only=True)
           
         plot_kwargs_fillbetween = plot_dict.copy()
         del plot_kwargs_fillbetween['marker']

--- a/melodies_monet/plots/satplots.py
+++ b/melodies_monet/plots/satplots.py
@@ -438,7 +438,7 @@ def make_spatial_overlay(df, vmodel, column_o=None, label_o=None, column_m=None,
         ylabel = column_o
     
     #Take the mean for each siteid
-    df_mean=df.groupby(['siteid'],as_index=False).mean()
+    df_mean=df.groupby(['siteid'],as_index=False).mean(numeric_only=True)
     
     #Take the mean over time for the model output
     vmodel_mean = vmodel[column_m].mean(dim='time').squeeze()

--- a/melodies_monet/plots/satplots.py
+++ b/melodies_monet/plots/satplots.py
@@ -157,7 +157,7 @@ def make_timeseries(df, df_reg=None,column=None, label=None, ax=None, avg_window
         matplotlib ax from previous occurrence so can overlay obs and model 
         results on the same plot
     avg_window : rule 
-        Pandas resampling rule (e.g., 'H', 'D')
+        Pandas resampling rule (e.g., 'h', 'D')
     ylabel : str
         Title of y-axis
     vmin : real number

--- a/melodies_monet/plots/surfplots.py
+++ b/melodies_monet/plots/surfplots.py
@@ -401,7 +401,7 @@ def make_timeseries(df, df_reg=None, column=None, label=None, ax=None, avg_windo
         matplotlib ax from previous occurrence so can overlay obs and model 
         results on the same plot
     avg_window : rule 
-        Pandas resampling rule (e.g., 'H', 'D')
+        Pandas resampling rule (e.g., 'h', 'D')
     ylabel : str
         Title of y-axis
     vmin : real number

--- a/melodies_monet/plots/surfplots.py
+++ b/melodies_monet/plots/surfplots.py
@@ -1250,7 +1250,7 @@ def scorecard_step4_GetRegionLUCDate(ds_name=None,region_list=None,datelist=None
             region_date_rural_here = []
             region_date_urban_here = []
             for i in range(len(region_here['Time'])):
-                date_here1 = region_here['Time'][i]
+                date_here1 = region_here['Time'].values[i]
                 timestamp = ((date_here1 - np.datetime64('1970-01-01T00:00:00'))/ np.timedelta64(1, 's'))
                 date_here = datetime.utcfromtimestamp(timestamp)  #this function== 1970,1,1 + timestamp(in seconds)
                 if date_here >= date_start_here and date_here <= date_end_here:

--- a/melodies_monet/plots/surfplots.py
+++ b/melodies_monet/plots/surfplots.py
@@ -43,7 +43,7 @@ def make_24hr_regulatory(df, col=None):
 def calc_24hr_ave_v1(df, col=None):
     df.index = df.time_local
     # select sites with nobs >=18, 75% completeness
-    df_24hr_ave = (df.groupby("siteid")[col].resample("D").sum(min_count=18)/df.groupby("siteid")[col].resample("D").count()).reset_index().dropna()
+    df_24hr_ave = (df.groupby("siteid")[col].resample("D").sum(min_count=18, numeric_only=True)/df.groupby("siteid")[col].resample("D").count()).reset_index().dropna()
     df = df.reset_index(drop=True)
     return df.merge(df_24hr_ave, on=["siteid", "time_local"])
 
@@ -67,10 +67,10 @@ def make_8hr_regulatory(df, col=None):
 
 def calc_8hr_rolling_max_v1(df, col=None, window=None):
     df.index = df.time_local
-    df_rolling = df.groupby("siteid")[col].rolling(window,min_periods=6,center=True, win_type="boxcar").mean().reset_index().dropna()
+    df_rolling = df.groupby("siteid")[col].rolling(window,min_periods=6,center=True, win_type="boxcar").mean(numeric_only=True).reset_index().dropna()
     # JianHe: select sites with nobs >=18, 75% completeness based on EPA
     df_rolling.index = df_rolling.time_local
-    df_rolling_max = df_rolling.groupby("siteid").resample("D").max(min_count=18).reset_index(drop=True).dropna()
+    df_rolling_max = df_rolling.groupby("siteid").resample("D").max(min_count=18, numeric_only=True).reset_index(drop=True).dropna()
     df = df.reset_index(drop=True)
     return df.merge(df_rolling_max, on=["siteid", "time_local"])
 
@@ -325,9 +325,9 @@ def make_spatial_bias(df, df_reg=None, column_o=None, label_o=None, column_m=Non
     if df_reg is not None:
         # JianHe: include options for percentile calculation (set in yaml file)
         if ptile is None:
-            df_mean=df_reg.groupby(['siteid'],as_index=False).mean()
+            df_mean=df_reg.groupby(['siteid'],as_index=False).mean(numeric_only=True)
         else:
-            df_mean=df_reg.groupby(['siteid'],as_index=False).quantile(ptile/100.)
+            df_mean=df_reg.groupby(['siteid'],as_index=False).quantile(ptile/100., numeric_only=True)
 
         #Specify val_max = vdiff. the sp_scatter_bias plot in MONET only uses the val_max value
         #and then uses -1*val_max value for the minimum.
@@ -337,9 +337,9 @@ def make_spatial_bias(df, df_reg=None, column_o=None, label_o=None, column_m=Non
     else:
         # JianHe: include options for percentile calculation (set in yaml file)
         if ptile is None:
-            df_mean=df.groupby(['siteid'],as_index=False).mean()
+            df_mean=df.groupby(['siteid'],as_index=False).mean(numeric_only=True)
         else:
-            df_mean=df.groupby(['siteid'],as_index=False).quantile(ptile/100.)
+            df_mean=df.groupby(['siteid'],as_index=False).quantile(ptile/100., numeric_only=True)
        
         #Specify val_max = vdiff. the sp_scatter_bias plot in MONET only uses the val_max value
         #and then uses -1*val_max value for the minimum.
@@ -697,7 +697,7 @@ def make_spatial_overlay(df, vmodel, column_o=None, label_o=None, column_m=None,
         ylabel = column_o
     
     #Take the mean for each siteid
-    df_mean=df.groupby(['siteid'],as_index=False).mean()
+    df_mean=df.groupby(['siteid'],as_index=False).mean(numeric_only=True)
     
     #Take the mean over time for the model output
     vmodel_mean = vmodel[column_m].mean(dim='time').squeeze()
@@ -1266,14 +1266,14 @@ def make_spatial_bias_exceedance(df, column_o=None, label_o=None, column_m=None,
 
     # calculate exceedance
     if column_o == 'OZONE_reg':
-        df_mean=df.groupby(['siteid'],as_index=False).quantile(0.95) #concentrations not used in plotting, get the correct format for plotting
+        df_mean=df.groupby(['siteid'],as_index=False).quantile(0.95, numeric_only=True) #concentrations not used in plotting, get the correct format for plotting
         # get the exceedance days for each site
         df_counto = df[df[column_o]> 70.].groupby(['siteid'],as_index=False)[column_o].count()
         df_countm = df[df[column_m]> 70.].groupby(['siteid'],as_index=False)[column_m].count()     
         ylabel2 = 'O3'  
  
     elif column_o == 'PM2.5_reg':
-        df_mean=df.groupby(['siteid'],as_index=False).mean() #concentrations not used in plotting, get the correct format for plotting
+        df_mean=df.groupby(['siteid'],as_index=False).mean(numeric_only=True) #concentrations not used in plotting, get the correct format for plotting
         # get the exceedance days for each site
         df_counto = df[df[column_o]> 35.].groupby(['siteid'],as_index=False)[column_o].count()
         df_countm = df[df[column_m]> 35.].groupby(['siteid'],as_index=False)[column_m].count()

--- a/melodies_monet/util/satellite_utilities.py
+++ b/melodies_monet/util/satellite_utilities.py
@@ -140,7 +140,7 @@ def omps_l3_daily_o3_pairing(model_data,obs_data,ozone_ppbv_varname):
     grid_adjust = xe.Regridder(model_data[['latitude','longitude']],obs_data[['latitude','longitude']],'bilinear')
     mod_col_obsgrid = grid_adjust(column)
     # Aggregate time-step to daily means
-    daily_mean = mod_col_obsgrid.groupby('time.date').mean().compute()
+    daily_mean = mod_col_obsgrid.groupby('time.date').mean(numeric_only=True).compute()
     
     # change dimension name for date to time
     daily_mean = daily_mean.rename({'date':'time'})

--- a/melodies_monet/util/tools.py
+++ b/melodies_monet/util/tools.py
@@ -80,7 +80,7 @@ def kolmogorov_zurbenko_filter(df, col, window, iterations):
     for i in range(iterations):
         z.index = z.time_local
         z = z.groupby('siteid')[col].rolling(
-            window, center=True, min_periods=1).mean().reset_index().dropna()
+            window, center=True, min_periods=1).mean(numeric_only=True).reset_index().dropna()
     df = df.reset_index(drop=True)
     return df.merge(z, on=['siteid', 'time_local'])
 
@@ -119,23 +119,26 @@ def long_to_wide(df):
 def calc_8hr_rolling_max(df, col=None, window=None):
     df.index = df.time_local
     df_rolling = df.groupby('siteid')[col].rolling(
-        window, center=True, win_type='boxcar').mean().reset_index().dropna()
+        window, center=True, win_type='boxcar').mean(
+                numeric_only=True).reset_index().dropna()
     df_rolling_max = df_rolling.groupby('siteid').resample(
-        'D', on='time_local').max().reset_index(drop=True)
+        'D', on='time_local').max(numeric_only=True).reset_index(drop=True)
     df = df.reset_index(drop=True)
     return df.merge(df_rolling_max, on=['siteid', 'time_local'])
 
 
 def calc_24hr_ave(df, col=None):
     df.index = df.time_local
-    df_24hr_ave = df.groupby('siteid')[col].resample('D').mean().reset_index()
+    df_24hr_ave = df.groupby('siteid')[col].resample('D').mean(
+            numeric_only=True).reset_index()
     df = df.reset_index(drop=True)
     return df.merge(df_24hr_ave, on=['siteid', 'time_local'])
 
 
 def calc_3hr_ave(df, col=None):
     df.index = df.time_local
-    df_3hr_ave = df.groupby('siteid')[col].resample('3H').mean().reset_index()
+    df_3hr_ave = df.groupby('siteid')[col].resample('3H').mean(
+            numeric_only=True).reset_index()
     df = df.reset_index(drop=True)
     return df.merge(df_3hr_ave, on=['siteid', 'time_local'])
 
@@ -143,7 +146,7 @@ def calc_3hr_ave(df, col=None):
 def calc_annual_ave(df, col=None):
     df.index = df.time_local
     df_annual_ave = df.groupby('siteid')[col].resample(
-        'A').mean().reset_index()
+        'A').mean(numeric_only=True).reset_index()
     df = df.reset_index(drop=True)
     return df.merge(df_annual_ave, on=['siteid', 'time_local'])
 

--- a/melodies_monet/util/tools.py
+++ b/melodies_monet/util/tools.py
@@ -137,7 +137,7 @@ def calc_24hr_ave(df, col=None):
 
 def calc_3hr_ave(df, col=None):
     df.index = df.time_local
-    df_3hr_ave = df.groupby('siteid')[col].resample('3H').mean(
+    df_3hr_ave = df.groupby('siteid')[col].resample('3h').mean(
             numeric_only=True).reset_index()
     df = df.reset_index(drop=True)
     return df.merge(df_3hr_ave, on=['siteid', 'time_local'])


### PR DESCRIPTION
This pull request adds the keyword `numeric_only=True` to relevant pandas objects,
i.e. pandas.core.groupby.DataFrameGroupBy and pandas.core.window.rolling.Rolling .
The relevant operations are `mean()`, `min()`, `max()`, `median()` and `quantile()`.
This makes it compatible with pandas 2.2.2, and should be a nice start for future proofing MM, without breaking backwards compatibility (i., e., pandas 1, for monet).


If we want to keep it future proof, we should also update the references to freq='H' to freq='h', but I am not sure about compatibility with older versions of pandas for this, so I have kept it the way it was for now.

This has been tested for the surface plots with wrf-chem and AirNow.

Let me know if additional tests are required.