### PR TITLE
fix bug that removed aircraftplots import line

### DIFF
--- a/melodies_monet/driver.py
+++ b/melodies_monet/driver.py
@@ -1322,6 +1322,7 @@ class analysis:
             from .plots import satplots as splots,savefig
         else: 
             from .plots import surfplots as splots, savefig
+            from .plots import aircraftplots as airplots
 
         # Disable figure count warning
         initial_max_fig = plt.rcParams["figure.max_open_warning"]


### PR DESCRIPTION
This line got accidentally removed during one of the satellite evaluation merges, so let's add it back in so that the aircraft plots are properly imported.