### PR TITLE
CLI: Include exception type name in non-debug message

### DIFF
--- a/melodies_monet/_cli.py
+++ b/melodies_monet/_cli.py
@@ -33,6 +33,20 @@ HEADER = """
 """.strip()
 
 
+def _get_full_name(obj):
+    """Get the full name of a function or type,
+    including the module name if not builtin."""
+    import builtins
+    import inspect
+
+    mod = inspect.getmodule(obj)
+    name = obj.__qualname__
+    if mod is None or mod is builtins:
+        return name
+    else:
+        return f"{mod.__name__}.{name}"
+
+
 @contextmanager
 def _timer(desc=""):
     start = time.perf_counter()
@@ -47,7 +61,7 @@ def _timer(desc=""):
             tpl.format(status="failed", elapsed=time.perf_counter() - start),
             fg=ERROR_COLOR
         )
-        typer.secho(f"Error message: {e}", fg=ERROR_COLOR)
+        typer.secho(f"Error message (type: {_get_full_name(type(e))}): {e}", fg=ERROR_COLOR)
         if DEBUG:
             raise
         else:

--- a/melodies_monet/tests/test_get_data_cli.py
+++ b/melodies_monet/tests/test_get_data_cli.py
@@ -15,6 +15,34 @@ ds0_aeronet = xr.open_dataset(fetch_example("aeronet:2019-09"))
 ds0_airnow = xr.open_dataset(fetch_example("airnow:2019-09"))
 
 
+def test_get_aeronet_no_data_err():
+    cmd = [
+        "melodies-monet",
+        "get-aeronet",
+        "-s", "2100-01-01",  # future
+        "-e", "2100-01-02",
+    ]
+    cp = subprocess.run(cmd, capture_output=True)
+    assert cp.returncode != 0
+    assert cp.stdout.decode().splitlines()[-2].startswith(
+        "Error message (type: Exception): loading from URL 'https://aeronet.gsfc.nasa.gov/"
+    )
+
+
+def test_get_aeronet_empty_date_range_err():
+    cmd = [
+        "melodies-monet",
+        "get-aeronet",
+        "-s", "2019-09-01",
+        "-e", "2019-08-31",
+    ]
+    cp = subprocess.run(cmd, capture_output=True)
+    assert cp.returncode != 0
+    assert cp.stdout.decode().splitlines()[-2] == (
+        "Error message (type: ValueError): Neither `start` nor `end` can be NaT"
+    )
+
+
 def test_get_aeronet(tmp_path):
     fn = "x.nc"
     cmd = [


### PR DESCRIPTION
With this change, there's a little bit more info about the error in `--no-debug` mode (default)

* [x] add a simple test