### PR TITLE
Update docs env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           python -c "import monet;   print('monet.__version__',   getattr(monet, '__version__', '?'))"
 
       - name: pytest
-        run: python -m pytest -v -rsx melodies_monet
+        run: python -m pytest -v -ra melodies_monet
       
       - name: Run docs/examples notebooks as scripts
         run: |

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,9 +1,9 @@
 version: 2
 
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-22.04"
   tools:
-    python: "mambaforge-4.10"
+    python: "mambaforge-23.11"
 
 sphinx:
   configuration: docs/conf.py

--- a/docs/appendix/machine-specific-install.rst
+++ b/docs/appendix/machine-specific-install.rst
@@ -128,7 +128,4 @@ environment for running and developing MELODIES MONET.
 
 .. [#ncar_jhub_kernel] Maintained by NCAR CISL and members of the MELODIES MONET development team.
 
-.. [#clone] See :ref:`the cloning notes <clone-notes>` if you have
-   trouble cloning the repositories this way.
-
 .. [#hera_no_pypi] Recent as of 12-Apr-2022. See :issue:`79`.

--- a/docs/appendix/machine-specific-install.rst
+++ b/docs/appendix/machine-specific-install.rst
@@ -115,7 +115,7 @@ environment for running and developing MELODIES MONET.
    with conda on Hera led to stalling.
    To overcome this challenge, try installing packages individually::
   
-        $ conda create --name melodies-monet python=3.9
+        $ conda create --name melodies-monet python=3.11
         $ conda activate melodies-monet
         $ conda install -c conda-forge jupyterlab
         $ conda install -c conda-forge netcdf4

--- a/docs/develop/developers_guide.rst
+++ b/docs/develop/developers_guide.rst
@@ -52,7 +52,7 @@ these instructions:
 (a) Set up a conda environment with all the dependencies, including MONET and 
     MONETIO::
 
-       $ conda create --name melodies-monet python=3.9
+       $ conda create --name melodies-monet python=3.11
        $ conda activate melodies-monet
        $ conda install -y -c conda-forge pyyaml pandas=1 'matplotlib-base<3.9' monet monetio netcdf4 wrf-python typer rich pooch jupyterlab
 

--- a/docs/environment-docs.yml
+++ b/docs/environment-docs.yml
@@ -23,11 +23,11 @@ dependencies:
   #
   # Docs
   - ipykernel
-  - jupyterlab=3.*
+  - jupyterlab=4.*
   - jupytext
   - myst-nb>=0.14
   - nbclient
-  - sphinx=4.*
+  - sphinx=7.*
   - sphinx-autobuild
   - sphinx-click
   - sphinx-design

--- a/docs/environment-docs.yml
+++ b/docs/environment-docs.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - python=3.9
+  - python=3.10
   #
   # melodies_monet deps
   - matplotlib-base<3.9  # for pandas v1 compat

--- a/docs/environment-docs.yml
+++ b/docs/environment-docs.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - python=3.10
+  - python=3.11
   #
   # melodies_monet deps
   - matplotlib-base<3.9  # for pandas v1 compat

--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -37,7 +37,7 @@ Option 1) Using Conda
 We have recently created a conda-forge release of MELODIES MONET to make installation very simple 
 with just 1 line of code below::
 
-    $ conda create --name melodies-monet -y -c conda-forge python=3.9 melodies-monet wrf-python jupyterlab
+    $ conda create --name melodies-monet -y -c conda-forge python=3.11 melodies-monet wrf-python jupyterlab
 
 .. note::
    Currently, the wrf-python conda package is not compatible with Apple Silicon (Apple machines using Intel should be fine). If you need to run the WRF-Chem reader and only have access to a machine using Apple Silicon, you can try compiling it from source code from the official repos.
@@ -50,7 +50,7 @@ conda-forge releases of MONET/MONETIO.
 
 First create and activate a conda environment::
 
-    $ conda create --name melodies-monet python=3.9
+    $ conda create --name melodies-monet python=3.11
     $ conda activate melodies-monet
 
 Add dependencies from conda-forge::


### PR DESCRIPTION
We could also update the docs to recommend Python ~~3.10~~ 3.11 instead of 3.9? @rschwant 