### PR TITLE
Make evenly spaced ticks when threshold_values are not evenly spaced in CSI plots

### DIFF
--- a/docs/appendix/yaml.rst
+++ b/docs/appendix/yaml.rst
@@ -351,7 +351,7 @@ for csi plot, list of model names (only) user choose to set as labels.
 
 **score_name:** csi plot only. list of scores user can choose to plot. examples are "Critical Success Index' 'False Alarm Rate' 'Hit Rate'.
 
-**threshold_tick_style:** csi plot only. (optional) control for spacing of threshold (x-axis) ticks. example: use ``nonlinear`` when nonlinear xticks are desired. Other selections (default = None) will choose xticks that are equally spaced between min(threshold_list):max(threshold_list).  
+**threshold_tick_style:** csi plot only. (optional) control for spacing of threshold (x-axis) ticks. example: use ``nonlinear`` when nonlinear xticks are desired. Other selections (default = None) will choose xticks that are equally spaced between min(threshold_list):max(threshold_list).   
 
 **data:** This a list of model / observation pairs to be plotted where the 
 observation label is first and the model label is second 

--- a/docs/appendix/yaml.rst
+++ b/docs/appendix/yaml.rst
@@ -351,7 +351,7 @@ for csi plot, list of model names (only) user choose to set as labels.
 
 **score_name:** csi plot only. list of scores user can choose to plot. examples are "Critical Success Index' 'False Alarm Rate' 'Hit Rate'.
 
-**threshold_tick_style:** csi plot only. (optional) control for spacing of threshold (x-axis) ticks. example: use ``unique`` when a unique xtick for each threshold value is desired. Any other selection (default = None) will choose xticks that are equally spaced between min(threshold_list):max(threshold_list).  
+**threshold_tick_style:** csi plot only. (optional) control for spacing of threshold (x-axis) ticks. example: use ``nonlinear`` when nonlinear xticks are desired. Any other selection (default = None) will choose xticks that are equally spaced between min(threshold_list):max(threshold_list).  
 
 **data:** This a list of model / observation pairs to be plotted where the 
 observation label is first and the model label is second 

--- a/docs/appendix/yaml.rst
+++ b/docs/appendix/yaml.rst
@@ -351,7 +351,7 @@ for csi plot, list of model names (only) user choose to set as labels.
 
 **score_name:** csi plot only. list of scores user can choose to plot. examples are "Critical Success Index' 'False Alarm Rate' 'Hit Rate'.
 
-**threshold_tick_style:** csi plot only. (optional) control for spacing of threshold (x-axis) ticks. example: use ``nonlinear`` when nonlinear xticks are desired. Any other selection (default = None) will choose xticks that are equally spaced between min(threshold_list):max(threshold_list).  
+**threshold_tick_style:** csi plot only. (optional) control for spacing of threshold (x-axis) ticks. example: use ``nonlinear`` when nonlinear xticks are desired. Other selections (default = None) will choose xticks that are equally spaced between min(threshold_list):max(threshold_list).  
 
 **data:** This a list of model / observation pairs to be plotted where the 
 observation label is first and the model label is second 

--- a/docs/appendix/yaml.rst
+++ b/docs/appendix/yaml.rst
@@ -351,6 +351,8 @@ for csi plot, list of model names (only) user choose to set as labels.
 
 **score_name:** csi plot only. list of scores user can choose to plot. examples are "Critical Success Index' 'False Alarm Rate' 'Hit Rate'.
 
+**threshold_tick_style:** csi plot only. (optional) control for spacing of threshold (x-axis) ticks. example: use ``unique`` when a unique xtick for each threshold value is desired. Any other selection (default = None) will choose xticks that are equally spaced between min(threshold_list):max(threshold_list).  
+
 **data:** This a list of model / observation pairs to be plotted where the 
 observation label is first and the model label is second 
 (e.g., ['airnow_cmaq_expt', 'airnow_rrfs_13km', 'airnow_wrfchem_v4.2'])

--- a/docs/appendix/yaml.rst
+++ b/docs/appendix/yaml.rst
@@ -351,7 +351,7 @@ for csi plot, list of model names (only) user choose to set as labels.
 
 **score_name:** csi plot only. list of scores user can choose to plot. examples are "Critical Success Index' 'False Alarm Rate' 'Hit Rate'.
 
-**threshold_tick_style:** csi plot only. (optional) control for spacing of threshold (x-axis) ticks. example: use ``nonlinear`` when nonlinear xticks are desired. Other selections (default = None) will choose xticks that are equally spaced between min(threshold_list):max(threshold_list).   
+**threshold_tick_style:** csi plot only. (optional) control for spacing of threshold (x-axis) ticks. example: use ``nonlinear`` when nonlinear xticks including all thresholds are desired. Any other selection (default = None) will choose xticks that are equally spaced between min(threshold_list):max(threshold_list) and likely won't include all thresholds. 
 
 **data:** This a list of model / observation pairs to be plotted where the 
 observation label is first and the model label is second 

--- a/docs/applications/forecasts.rst
+++ b/docs/applications/forecasts.rst
@@ -10,10 +10,10 @@ including a newly developed research forecast model called RAP-chem every day
 in near real time against the AirNow surface observations of ozone, PM\ :sub:`2.5`\, 
 CO, and NO\ :sub:`2` and AERONET AOD measurements.
 
-Check out the full analysis for each forecast `here <https://rapidrefresh.noaa.gov/RAPchemEPA/>`__.
+Check out the full analysis for each forecast `here <https://rapidrefresh.noaa.gov/monet_rrfs_verif/>`__.
 
 This includes a new feature developed by NOAA GSL summer student, Mackenzie Arnold,
-to `interactively view plots for individual surface sites online <https://rapidrefresh.noaa.gov/RAPchemEPAsites/>`__.
+to `interactively view plots for individual surface sites online <https://rapidrefresh.noaa.gov/monet_rrfs_verif/>`__.
 
 The code to produce this analysis using MELODIES MONET is in the
 ``examples/forecast_evaluation`` folder on GitHub.

--- a/melodies_monet/driver.py
+++ b/melodies_monet/driver.py
@@ -1502,6 +1502,7 @@ class analysis:
                 threshold_list = grp_dict['threshold_list']
                 score_name = grp_dict['score_name']
                 model_name_list = grp_dict['model_name_list']
+                xtick_style = grp_dict.get('xtick_style',None)
 
             # first get the observational obs labels
             pair1 = self.paired[list(self.paired.keys())[0]]
@@ -2392,7 +2393,8 @@ class analysis:
                                                 text_dict=text_dict,
                                                 domain_type=domain_type,
                                                 domain_name=domain_name,
-                                                model_name_list=model_name_list)
+                                                model_name_list=model_name_list,
+                                                xtick_style=xtick_style)
                                 #save figure
                                 plt.tight_layout()
                                 savefig(outname +'.'+score_name+'.png', loc=1, logo_height=100) 

--- a/melodies_monet/driver.py
+++ b/melodies_monet/driver.py
@@ -1502,7 +1502,7 @@ class analysis:
                 threshold_list = grp_dict['threshold_list']
                 score_name = grp_dict['score_name']
                 model_name_list = grp_dict['model_name_list']
-                xtick_style = grp_dict.get('xtick_style',None)
+                threshold_tick_style = grp_dict.get('threshold_tick_style',None)
 
             # first get the observational obs labels
             pair1 = self.paired[list(self.paired.keys())[0]]
@@ -2394,7 +2394,7 @@ class analysis:
                                                 domain_type=domain_type,
                                                 domain_name=domain_name,
                                                 model_name_list=model_name_list,
-                                                xtick_style=xtick_style)
+                                                threshold_tick_style=threshold_tick_style)
                                 #save figure
                                 plt.tight_layout()
                                 savefig(outname +'.'+score_name+'.png', loc=1, logo_height=100) 

--- a/melodies_monet/plots/surfplots.py
+++ b/melodies_monet/plots/surfplots.py
@@ -1534,7 +1534,7 @@ def Calc_Score(score_name_input,threshold_input, model_input, obs_input):
    
     return output_score
 
-def Plot_CSI(score_name_input,threshold_list_input, comb_bx_input,plot_dict,fig_dict,text_dict,domain_type,domain_name,model_name_list):
+def Plot_CSI(score_name_input,threshold_list_input, comb_bx_input,plot_dict,fig_dict,text_dict,domain_type,domain_name,model_name_list,xtick_style):
 
     CSI_output = []  #(2, threshold len)
     threshold_list = threshold_list_input
@@ -1566,8 +1566,10 @@ def Plot_CSI(score_name_input,threshold_list_input, comb_bx_input,plot_dict,fig_
 
     #Make Plot
     for i in range(len(CSI_output)):
-        threshold_string_array = [str(x) for x in threshold_list]
-        plt.plot(range(len(threshold_list)),CSI_output[i],'-*',label=model_name_list[i])
+        if xtick_style == 'equal':
+           plt.plot(range(len(threshold_list)),CSI_output[i],'-*',label=model_name_list[i])
+        else:
+           plt.plot(threshold_list,CSI_output[i],'-*',label=model_name_list[i])
         ax.set_xlabel('Threshold',fontsize = text_kwargs['fontsize']*0.8)
         ax.set_ylabel(score_name_input,fontsize = text_kwargs['fontsize']*0.8)
         ax.tick_params(labelsize=text_kwargs['fontsize']*0.8)
@@ -1576,8 +1578,13 @@ def Plot_CSI(score_name_input,threshold_list_input, comb_bx_input,plot_dict,fig_
         plt.grid()
      
     #add '>' to xticks
-    labels = ['>'+item for item in threshold_string_array]
-    ax.set_xticks(range(len(threshold_list)),labels=labels)
+    if xtick_style == 'equal':
+       threshold_string_array = [str(x) for x in threshold_list]
+       ax.set_xticks(range(len(threshold_list)),labels=labels)
+    else
+       labels = ['>'+item.get_text() for item in ax.get_xticklabels()]
+       ax.set_xticklabels(labels)
+
     if domain_type is not None and domain_name is not None:
         if domain_type == 'epa_region':
             ax.set_title('EPA Region ' + domain_name,fontweight='bold',**text_kwargs)

--- a/melodies_monet/plots/surfplots.py
+++ b/melodies_monet/plots/surfplots.py
@@ -1580,6 +1580,7 @@ def Plot_CSI(score_name_input,threshold_list_input, comb_bx_input,plot_dict,fig_
     #add '>' to xticks
     if xtick_style == 'equal':
        threshold_string_array = [str(x) for x in threshold_list]
+       labels = ['>'+item for item in threshold_string_array]
        ax.set_xticks(range(len(threshold_list)),labels=labels)
     else
        labels = ['>'+item.get_text() for item in ax.get_xticklabels()]

--- a/melodies_monet/plots/surfplots.py
+++ b/melodies_monet/plots/surfplots.py
@@ -1582,7 +1582,7 @@ def Plot_CSI(score_name_input,threshold_list_input, comb_bx_input,plot_dict,fig_
        threshold_string_array = [str(x) for x in threshold_list]
        labels = ['>'+item for item in threshold_string_array]
        ax.set_xticks(range(len(threshold_list)),labels=labels)
-    else
+    else:
        labels = ['>'+item.get_text() for item in ax.get_xticklabels()]
        ax.set_xticklabels(labels)
 

--- a/melodies_monet/plots/surfplots.py
+++ b/melodies_monet/plots/surfplots.py
@@ -1566,7 +1566,8 @@ def Plot_CSI(score_name_input,threshold_list_input, comb_bx_input,plot_dict,fig_
 
     #Make Plot
     for i in range(len(CSI_output)):
-        plt.plot(threshold_list,CSI_output[i],'-*',label=model_name_list[i])  #CHANGE THIS ONE, MAIN PROGRAM
+        threshold_string_array = [str(x) for x in threshold_list]
+        plt.plot(range(len(threshold_list)),CSI_output[i],'-*',label=model_name_list[i])
         ax.set_xlabel('Threshold',fontsize = text_kwargs['fontsize']*0.8)
         ax.set_ylabel(score_name_input,fontsize = text_kwargs['fontsize']*0.8)
         ax.tick_params(labelsize=text_kwargs['fontsize']*0.8)
@@ -1575,8 +1576,8 @@ def Plot_CSI(score_name_input,threshold_list_input, comb_bx_input,plot_dict,fig_
         plt.grid()
      
     #add '>' to xticks
-    labels = ['>'+item.get_text() for item in ax.get_xticklabels()]
-    ax.set_xticklabels(labels)
+    labels = ['>'+item for item in threshold_string_array]
+    ax.set_xticks(range(len(threshold_list)),labels=labels)
     if domain_type is not None and domain_name is not None:
         if domain_type == 'epa_region':
             ax.set_title('EPA Region ' + domain_name,fontweight='bold',**text_kwargs)

--- a/melodies_monet/plots/surfplots.py
+++ b/melodies_monet/plots/surfplots.py
@@ -1534,7 +1534,7 @@ def Calc_Score(score_name_input,threshold_input, model_input, obs_input):
    
     return output_score
 
-def Plot_CSI(score_name_input,threshold_list_input, comb_bx_input,plot_dict,fig_dict,text_dict,domain_type,domain_name,model_name_list,xtick_style):
+def Plot_CSI(score_name_input,threshold_list_input, comb_bx_input,plot_dict,fig_dict,text_dict,domain_type,domain_name,model_name_list,threshold_tick_style):
 
     CSI_output = []  #(2, threshold len)
     threshold_list = threshold_list_input
@@ -1566,7 +1566,7 @@ def Plot_CSI(score_name_input,threshold_list_input, comb_bx_input,plot_dict,fig_
 
     #Make Plot
     for i in range(len(CSI_output)):
-        if xtick_style == 'equal':
+        if threshold_tick_style == 'unique':
            plt.plot(range(len(threshold_list)),CSI_output[i],'-*',label=model_name_list[i])
         else:
            plt.plot(threshold_list,CSI_output[i],'-*',label=model_name_list[i])
@@ -1578,7 +1578,7 @@ def Plot_CSI(score_name_input,threshold_list_input, comb_bx_input,plot_dict,fig_
         plt.grid()
      
     #add '>' to xticks
-    if xtick_style == 'equal':
+    if threshold_tick_style == 'unique':
        threshold_string_array = [str(x) for x in threshold_list]
        labels = ['>'+item for item in threshold_string_array]
        ax.set_xticks(range(len(threshold_list)),labels=labels)

--- a/melodies_monet/plots/surfplots.py
+++ b/melodies_monet/plots/surfplots.py
@@ -1566,7 +1566,7 @@ def Plot_CSI(score_name_input,threshold_list_input, comb_bx_input,plot_dict,fig_
 
     #Make Plot
     for i in range(len(CSI_output)):
-        if threshold_tick_style == 'unique':
+        if threshold_tick_style == 'nonlinear':
            plt.plot(range(len(threshold_list)),CSI_output[i],'-*',label=model_name_list[i])
         else:
            plt.plot(threshold_list,CSI_output[i],'-*',label=model_name_list[i])
@@ -1578,7 +1578,7 @@ def Plot_CSI(score_name_input,threshold_list_input, comb_bx_input,plot_dict,fig_
         plt.grid()
      
     #add '>' to xticks
-    if threshold_tick_style == 'unique':
+    if threshold_tick_style == 'nonlinear':
        threshold_string_array = [str(x) for x in threshold_list]
        labels = ['>'+item for item in threshold_string_array]
        ax.set_xticks(range(len(threshold_list)),labels=labels)


### PR DESCRIPTION
CSI plots with non-monotonic thresholds not displayed neatly. 

threshold_list: [1,2,5,10,15,20,30,50,100,200]

Old:

![plot_grp7 csi PM2 5 2024-10-24_00 2024-10-26_00 isinconus CONUS Critical Success Index](https://github.com/user-attachments/assets/2c6bcbab-69dc-4c7c-98a0-099252cb3f0a)

Update:

![plot_grp7 csi PM2 5 2024-10-25_00 2024-10-27_00 isinconus CONUS Critical Success Index](https://github.com/user-attachments/assets/cf515af0-8462-4c8d-a21e-0611e6cd0cd7)
