### PR TITLE
longitude wrap satellite level 3 pairing

### DIFF
--- a/melodies_monet/util/satellite_utilities.py
+++ b/melodies_monet/util/satellite_utilities.py
@@ -78,7 +78,7 @@ def mopitt_l3_pairing(model_data,obs_data,co_ppbv_varname):
         raise
     # initialize regridder for horizontal interpolation 
     # from model grid to MOPITT grid
-    grid_adjust = xe.Regridder(model_obstime[['latitude','longitude']],obs_data[['lat','lon']],'bilinear')
+    grid_adjust = xe.Regridder(model_obstime[['latitude','longitude']],obs_data[['lat','lon']],'bilinear',periodic=True)
     co_model_regrid = grid_adjust(model_obstime[co_ppbv_varname])
     pressure_model_regrid = grid_adjust(model_obstime['pres_pa_mid']/100.)
     
@@ -137,7 +137,7 @@ def omps_l3_daily_o3_pairing(model_data,obs_data,ozone_ppbv_varname):
     column = (du_fac*(model_data['dp_pa']/100.)*model_data[ozone_ppbv_varname]).sum('z')
     
     # initialize regrid and apply to column data
-    grid_adjust = xe.Regridder(model_data[['latitude','longitude']],obs_data[['latitude','longitude']],'bilinear')
+    grid_adjust = xe.Regridder(model_data[['latitude','longitude']],obs_data[['latitude','longitude']],'bilinear',periodic=True)
     mod_col_obsgrid = grid_adjust(column)
     # Aggregate time-step to daily means
     daily_mean = mod_col_obsgrid.resample(time='1D').mean()


### PR DESCRIPTION
Add periodic=True for regridding model data to level 3 satellite data to allow regrid function to handle longitude wrap. 

This is a temporary work around as it assumes the model is a global model. To properly allow for flexible comparison of satellite level 3 products and any model domain (regional or global), need a function to subset satellite observations to the model domain and/or associate a model domain type flag with the model object. 