### PR TITLE
Update aircraft pairing (no changes to results)

### DIFF
--- a/melodies_monet/util/tools.py
+++ b/melodies_monet/util/tools.py
@@ -323,15 +323,6 @@ def vert_interp(ds_model,df_obs,var_name_list):
     df_model.drop(labels=['x','y','z','pressure_obs','time_obs'], axis=1, inplace=True)
     df_model.rename(columns={'pressure_model':'pressure_obs'}, inplace=True)
 
-    #Confirm that extra digits will not break the pairing at the merge_asof step by rounding to the 8th digit
-    df_model.latitude = df_model.latitude.round(8)
-    df_model.longitude = df_model.longitude.round(8)
-    df_model.pressure_obs = df_model.pressure_obs.round(8)
-
-    df_obs.latitude = df_obs.latitude.round(8)
-    df_obs.longitude = df_obs.longitude.round(8)
-    df_obs.pressure_obs = df_obs.pressure_obs.round(8)
-    
     final_df_model = merge_asof(df_obs, df_model, 
                             by=['latitude', 'longitude', 'pressure_obs'], 
                             on='time', direction='nearest')

--- a/melodies_monet/util/tools.py
+++ b/melodies_monet/util/tools.py
@@ -313,10 +313,25 @@ def vert_interp(ds_model,df_obs,var_name_list):
         var_out_list.append(out)
 
     df_model = xr.merge(var_out_list).to_dataframe().reset_index()
-    df_model.fillna({'pressure_model':df_model.pressure_obs},inplace=True)
+    for time in df_model.time.unique():
+        if df_model[df_model.time == time].pressure_obs.unique() > df_model[df_model.time == time].pressure_model.max():
+            df_model.fillna({'pressure_model':df_model[df_model.time == time].pressure_obs},inplace=True)
+        elif df_model[df_model.time == time].pressure_obs.unique() < df_model[df_model.time == time].pressure_model.min():
+            df_model.fillna({'pressure_model':df_model[df_model.time == time].pressure_obs},inplace=True)
+            print('Warning: You are pairing obs data above the model top. This is not recommended.')
+            print(time)
     df_model.drop(labels=['x','y','z','pressure_obs','time_obs'], axis=1, inplace=True)
     df_model.rename(columns={'pressure_model':'pressure_obs'}, inplace=True)
 
+    #Confirm that extra digits will not break the pairing at the merge_asof step by rounding to the 8th digit
+    df_model.latitude = df_model.latitude.round(8)
+    df_model.longitude = df_model.longitude.round(8)
+    df_model.pressure_obs = df_model.pressure_obs.round(8)
+
+    df_obs.latitude = df_obs.latitude.round(8)
+    df_obs.longitude = df_obs.longitude.round(8)
+    df_obs.pressure_obs = df_obs.pressure_obs.round(8)
+    
     final_df_model = merge_asof(df_obs, df_model, 
                             by=['latitude', 'longitude', 'pressure_obs'], 
                             on='time', direction='nearest')


### PR DESCRIPTION
The ASIA-AQ WRF-Chem test NaNed many points during the pairing step. It looks like because there were tacked on 0.000001 values to the end of some of the numbers in lat, lon, and pressure (e.g., 120.0000001) and then the vertical pairing step could not match these values properly. I added code to round before this pairing occurs to truncate these extra digits. @colin-harkins and @zmoon, is there a better way to do this? I've seen this happen before with pulling in .txt files into Python and I'm not sure why sometimes this happens. Is this rounding approach an okay fix? I want to make sure this code works for all icartt files even if there are some odd formatting, so I think this is safer.

I also as I was going through the code to find the problem realized that we really only want to replace the pressure_model NaNed points with pressure_obs when the pressure_obs is outside of the range of the model data. Right now it is doing this for all time steps. I tested that you get the same results doing both methods because merge_asof "nearest" approach selects the right point anyway in FIREX-AQ, RECAP, and AEROMMA, but I think the code is cleaner this way and less likely to have problems later on.

Let me know what you all think! Thanks!