### PR TITLE
Fix for np.float deprecation

### DIFF
--- a/melodies_monet/util/sat_l2_swath_utility.py
+++ b/melodies_monet/util/sat_l2_swath_utility.py
@@ -143,7 +143,7 @@ def trp_interp_swatogrd_ak(obsobj, modobj):
     modlat = modobj.coords['latitude']
     modlon = modobj.coords['longitude']
 
-    tmpvalue = np.zeros([ny, nx], dtype = np.float)
+    tmpvalue = np.zeros([ny, nx], dtype = np.float64)
 
     time   = [ datetime.strptime(x,'%Y-%m-%d') for x in obsobj.keys()]
     ntime  = len(list(obsobj.keys()))


### PR DESCRIPTION
Pairing code for TROPOMI NO2 used `np.float` in one line. 
The np.float alias was deprecated in the Numpy 1.20.0 release (see https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations).