### PR TITLE
Bugfix: suffix when merging mobile_or_aircraft

### DIFF
--- a/melodies_monet/util/tools.py
+++ b/melodies_monet/util/tools.py
@@ -353,7 +353,7 @@ def mobile_and_ground_pair(ds_model,df_obs, var_name_list):
 
     final_df_model = merge_asof(df_obs, df_model, 
                             by=['latitude', 'longitude'], 
-                            on='time', direction='nearest')
+                            on='time', direction='nearest', suffixes=('', '_new'))
 
     return final_df_model
 


### PR DESCRIPTION
Previously it would add the defaul _x, _y, but MELODIES-MONET expects '', '_new'. This addresses #307 