### PR TITLE
Update jlord link top-level domain

### DIFF
--- a/docs/develop/developers_guide.rst
+++ b/docs/develop/developers_guide.rst
@@ -166,7 +166,7 @@ project on GitHub to learn about current and future development.
    `added an SSH key <https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account>`__
    to your GitHub account for your current machine.
    If you are new to GitHub, check out
-   `this GitHub tutorial <https://jlord.us/git-it/>`__.
+   `this GitHub tutorial <https://jlord.computer/git-it/>`__.
    We recommend the SSH method, but if you don't add an SSH key
    you can still clone the repositories via HTTPS, e.g. ::
 


### PR DESCRIPTION
Recently this link became broken

http://jlord.us/ does redirect to https://jlord.computer/

though https://jlord.us/ does not
and sub-pages under `jlord.us/` don't either