### PR TITLE
Update ozonesonder name and fix pairing

### DIFF
--- a/docs/develop/development_team.rst
+++ b/docs/develop/development_team.rst
@@ -30,7 +30,7 @@ Margaret Bruckner  mbruckner-work  Docs, Satellite obs, Plots, Stats
 Rebecca Buchholz   rrbuchholz      Docs, Satellite obs, Plots, Stats
 Pablo Lichtig      blychs          Docs, Satellite and surface obs, Plots, Stats
 Quazi Ziaur Rasool quaz115         Docs, Aircraft obs, Plots, Stats
-Beiming Tang       btang1          Docs, Surface and ozone sonder obs, Plots, Stats
+Beiming Tang       btang1          Docs, Surface and sonde obs, Plots, Stats
 ================== =============== ========================================================
 
 Development Team Members

--- a/docs/examples/control_ufsaqm_ozonesonde.yaml
+++ b/docs/examples/control_ufsaqm_ozonesonde.yaml
@@ -49,7 +49,7 @@ model:
 obs:
   gml-ozonesondes: # obs label
     filename: 'example:gml-100m-ozonesondes:as-of-2024-02-09'
-    obs_type: ozone_sonder
+    obs_type: sonde
     variables: #Opt 
       o3:
         unit_scale: 1000 #Opt Scaling factor (original ppmv, convert to ppbv)

--- a/docs/users_guide/supported_datasets.rst
+++ b/docs/users_guide/supported_datasets.rst
@@ -103,7 +103,7 @@ Pairing capabilities include time, horizontal, and vertical interpolation. Horiz
 nearest neighbor approach. Vertical interpolation uses linear interpolation and nearest neighbor for extrapolation 
 with a warning if users are pairing points above the model top, which is not recommended. Users can evaluate aircraft data, 
 ozonesonde data, mobile or walking data, and single ground site data. To use these options in MELODIES MONET 
-specify "obs_type" equal to "aircraft", "ozone_sonder", "mobile", or "ground" in your YAML file. The table 
+specify "obs_type" equal to "aircraft", "sonde", "mobile", or "ground" in your YAML file. The table 
 below describes these options in more detail. Available datafile formats include NetCDF, ICARTT, and CSV.
 
 .. list-table:: Description of YAML File Options for "obs_type" For Campaign Data
@@ -114,8 +114,8 @@ below describes these options in more detail. Available datafile formats include
      - Description of Pairing
    * - "aircraft"
      - Aircraft - Time, horizontal, and vertical interpolation across the entire dataset.
-   * - "ozone_sonder"
-     - | Ozonesonde - Vertical interpolation across the entire dataset. Time and 
+   * - "sonde"
+     - | Sonde - Vertical interpolation across the entire dataset. Time and 
        | horizontal interpolation at a fixed release time and location.
    * - "mobile"
      - Mobile - Time and horizontal interpolation across the entire dataset at the surface.

--- a/melodies_monet/driver.py
+++ b/melodies_monet/driver.py
@@ -1258,7 +1258,7 @@ class analysis:
                     self.paired[label] = p
                     # write_util.write_ncf(p.obj,p.filename) # write out to file
 
-                elif obs.obs_type.lower() == 'ozone_sonder':
+                elif obs.obs_type.lower() == 'sonde':
                     from .util.tools import vert_interp
                     # convert this to pandas dataframe unless already done because second time paired this obs
                     if not isinstance(obs.obj, pd.DataFrame):
@@ -1267,15 +1267,16 @@ class analysis:
                     obs.obj = obs.obj.reset_index().dropna(subset=['pressure_obs','latitude','longitude']).set_index('time')
  
                     import datetime 
-                    plot_dict_ozone_sonder = self.control_dict['plots']
-                    for grp_ozone_sonder, grp_dict_ozone_sonder in plot_dict_ozone_sonder.items():
-                        plot_type_ozone_sonder = grp_dict_ozone_sonder['type']
-                        plot_os_type_list_all = ['vertical_single_date','vertical_boxplot_os','density_scatter_plot_os']
-                        if plot_type_ozone_sonder in plot_os_type_list_all:
-                           station_name_os = grp_dict_ozone_sonder['station_name']
-                           cds_os = grp_dict_ozone_sonder['compare_date_single']
-                           obs.obj=obs.obj.loc[obs.obj['station']==station_name_os[0]]
-                           obs.obj=obs.obj.loc[datetime.datetime(cds_os[0],cds_os[1],cds_os[2],cds_os[3],cds_os[4],cds_os[5])]
+                    plot_dict_sonde = self.control_dict['plots']
+                    for grp_sonde, grp_dict_sonde in plot_dict_sonde.items():
+                        plot_type_sonde = grp_dict_sonde['type']
+                        plot_sonde_type_list_all = ['vertical_single_date','vertical_boxplot_os','density_scatter_plot_os']
+                        if plot_type_sonde in plot_sonde_type_list_all:
+                           station_name_sonde = grp_dict_sonde['station_name']
+                           cds_sonde = grp_dict_sonde['compare_date_single']
+                           obs.obj=obs.obj.loc[obs.obj['station']==station_name_sonde[0]]
+                           obs.obj=obs.obj.loc[datetime.datetime(
+                               cds_sonde[0],cds_sonde[1],cds_sonde[2],cds_sonde[3],cds_sonde[4],cds_sonde[5])]
                            break
                    
                     # do the facy trick to convert to get something useful for MONET
@@ -1290,7 +1291,7 @@ class analysis:
                     print('In pair function, After pairing: ', paired_data)
                     # this outputs as a pandas dataframe.  Convert this to xarray obj
                     p = pair()
-                    p.type = 'ozone_sonder'
+                    p.type = 'sonde'
                     p.radius_of_influence = None
                     p.obs = obs.label
                     p.model = mod.label
@@ -1508,7 +1509,7 @@ class analysis:
         else: 
             from .plots import surfplots as splots, savefig
             from .plots import aircraftplots as airplots
-            from .plots import ozone_sonder_plots as sonderplots
+            from .plots import sonde_plots as sondeplots
 
         if not self.add_logo:
             savefig.keywords.update(decorate=False)
@@ -1547,7 +1548,7 @@ class analysis:
                 region_list = grp_dict['region_list']
                 model_name_list = grp_dict['model_name_list']     
 
-            #read-in special settings for ozone sonder related plots
+            #read-in special settings for ozone sonde related plots
             if plot_type in {'vertical_single_date', 'vertical_boxplot_os', 'density_scatter_plot_os'}:
                 altitude_range = grp_dict['altitude_range']
                 altitude_method = grp_dict['altitude_method']
@@ -1740,7 +1741,7 @@ class analysis:
                             pairdf_all = pairdf_all.loc[pairdf_all[grp_var].isin(grp_select[grp_var].values)]
 
                         # Drop NaNs if using pandas 
-                        if obs_type in ['pt_sfc','aircraft','mobile','ground','ozone_sonder']: 
+                        if obs_type in ['pt_sfc','aircraft','mobile','ground','sonde']: 
                             if grp_dict['data_proc']['rem_obs_nan'] == True:
                                 # I removed drop=True in reset_index in order to keep 'time' as a column.
                                 pairdf = pairdf_all.reset_index().dropna(subset=[modvar, obsvar])
@@ -2160,7 +2161,7 @@ class analysis:
                                 comb_bx, label_bx = splots.calculate_boxplot(pairdf, pairdf_reg, column=obsvar, label=p.obs, plot_dict=obs_dict)
                             comb_bx, label_bx = splots.calculate_boxplot(pairdf, pairdf_reg, column=modvar, label=p.model, plot_dict=plot_dict, comb_bx = comb_bx, label_bx = label_bx)
                             if p_index == len(pair_labels) - 1:
-                                sonderplots.make_vertical_single_date(pairdf,
+                                sondeplots.make_vertical_single_date(pairdf,
                                                                       comb_bx,
                                                                       altitude_range=altitude_range,
                                                                       altitude_method=altitude_method,
@@ -2197,7 +2198,7 @@ class analysis:
                             comb_bx, label_bx = splots.calculate_boxplot(pairdf, pairdf_reg, column=modvar, label=p.model, plot_dict=plot_dict, comb_bx = comb_bx, label_bx = label_bx)
 
                             if p_index == len(pair_labels) - 1:
-                                sonderplots.make_vertical_boxplot_os(pairdf,
+                                sondeplots.make_vertical_boxplot_os(pairdf,
                                                                      comb_bx,
                                                                      label_bx=label_bx,
                                                                      altitude_range=altitude_range,
@@ -2230,7 +2231,7 @@ class analysis:
 
                             #begin plotting
                             plt.figure()
-                            sonderplots.density_scatter_plot_os(pairdf,altitude_range,vmin,vmax,station_name,altitude_method,cmap_method,modvar,obsvar)
+                            sondeplots.density_scatter_plot_os(pairdf,altitude_range,vmin,vmax,station_name,altitude_method,cmap_method,modvar,obsvar)
                             plt.title('Scatter plot for '+model_name_list[0]+' vs. '+model_name_list[p_index+1]+'\nat '+str(station_name[0])+' on '+str(release_time)+' UTC',fontsize=15)
                             plt.tight_layout()
                             savefig(outname+"."+p_label+"."+"-".join(altitude_method[0].split())+".png", loc=monet_logo_position[0], logo_height=100, dpi=300)

--- a/melodies_monet/plots/sonde_plots.py
+++ b/melodies_monet/plots/sonde_plots.py
@@ -7,7 +7,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 sns.set_context('paper')
 
-#Define ozone sonder, vertical single date plot
+#Define ozone sonde, vertical single date plot
 def make_vertical_single_date(df,comb_bx,altitude_range,altitude_method,vmin, vmax,station_name,release_time,label_bx,fig_dict,text_dict):
     ALT_sl = df['altitude']
     O3_OBS = comb_bx[comb_bx.columns[0]].to_list()
@@ -60,7 +60,7 @@ def make_vertical_single_date(df,comb_bx,altitude_range,altitude_method,vmin, vm
     ax.set_ylabel(alt_p_name,fontsize=text_kwargs['fontsize']*0.8)
     ax.set_xlabel(ylabel+' (ppbv)',fontsize=text_kwargs['fontsize']*0.8)
 
-#Define ozone sonder, vertical single date plot
+#Define ozone sonde, vertical single date plot
 def make_vertical_boxplot_os(df,comb_bx,label_bx,altitude_range,altitude_method,vmin, vmax,altitude_threshold_list,station_name,release_time,fig_dict,text_dict):
     ALT_sl = df['altitude']
     O3_OBS = comb_bx[comb_bx.columns[0]].to_list()
@@ -161,7 +161,7 @@ def density_scatter_plot_os(df,altitude_range,vmin,vmax,station_name,altitude_me
     elif altitude_method[0] == 'sea level':
         height_value = 0
 
-    #get o3 model, o3 sonder (obs) and height
+    #get o3 model, o3 sonde (obs) and height
     df_short = df[df['altitude']<altitude_range[1]+height_value]
     ALT = df_short['altitude']-height_value
     O3_OBS = df_short[obsvar]  #'o3'


### PR DESCRIPTION
This PR fixes the ozonesonder name to sonde. During this process I realized that the pairing with the latest update was not working correctly for ozonesondes anymore. The fastest fix was to just update the time to x in the tools.py vert_interp code. But then I figured I should test whether the code works correctly if it has a point in the observation above the model top. This is kind of unusual for air quality / atmospheric composition datasets that focus on the troposphere, but good for version 1 to work in all situations. It did not work correctly. So I realized that using NaN for extrapolation with pressure_model and then replacing these NaNs with the pressure_obs values for pairing does not work for all conditions. Although I did check and the update I made here does not change any current pairing for ozonesondes, FIREX-AQ, or AEROMMA (because these datasets don't get above the model top), so this update does not impact past troposphere centric work (and probably why we never noticed an issue before), but would be useful for new work that might go into the stratosphere more. 

The newest vertical pairing works like the following: 
For each point in the observations for all variables, linear interpolation and nearest extrapolation occurs for all pressure_obs available in the dataset using stratify (a very fast C++ routine). Then we need to pick the correct pressure_model point for each point in the observation file. To do this we now just have pressure_model use extrapolation linear. This gives the exact value of the pressure_obs and then selecting the right point is trivial. Not sure why I didn't think of doing this before, but this is far cleaner than the NaN approach and replacing the NaNs correctly. I think I had thought that this linear approach would not always give you the pressure_obs value, but in my tests it seems to work fine. Then I have also a NaN extrapolation that is used to print out a Note if there is a point below the lowest mid-level value in the model and a warning if there is a point above the highest mid-level value in the model. This way if someone has odd unit conversions they probably will notice right away with all the points being above or below their model values.

Let me know what you all think about these changes. I'll email 4 jupyter notebooks (I cannot attach .ipynb files and when I pdf them it is not as clear) to look though if you like for the ozonesonde and FIREX-AQ case both of which I added a fake value above the model top for testing. Again if I do not add this fake model top value, you get the same results with the old and new way. I include jupyter notebooks for this too.