### PR TITLE
Fix summing for observations when variables not provided

### DIFF
--- a/melodies_monet/driver.py
+++ b/melodies_monet/driver.py
@@ -397,6 +397,8 @@ class observation:
                         print('The variable name, {}, already exists and cannot be created with variable_summing.'.format(var_new))
                         raise ValueError
                     var_new_info = self.variable_summing[var_new]
+                    if self.variable_dict is None:
+                        self.variable_dict = {}
                     self.variable_dict[var_new] = var_new_info
                     for i,var in enumerate(var_new_info['vars']):
                         if i ==0:


### PR DESCRIPTION
Fix that variable summing works for observation class too when variables are not provided. Not providing information on variables for the observations is not very likely, but not technically required, so it is good that the code is more flexible with this update.

The model fix is in Beiming's PR here: https://github.com/NOAA-CSL/MELODIES-MONET/pull/347

Both updates are the same and I confirmed that this update works well for the observations too.

This along with Beiming's PR will close out this issue: Variable summing update to work in all cases
[#319](https://github.com/NOAA-CSL/MELODIES-MONET/issues/319)