### PR TITLE
Hotfix: read plot defaults (reverse regression)

### DIFF
--- a/melodies_monet/driver.py
+++ b/melodies_monet/driver.py
@@ -1962,6 +1962,7 @@ class analysis:
                             else:
                                 plot_kwargs['column']=modvar
                             plot_kwargs['label'] = p.model
+                            plot_kwargs['plot_dict'] = plot_dict
                             plot_kwargs['ax'] = ax
                             ax = make_timeseries(**plot_kwargs)
 


### PR DESCRIPTION
This fixes a regression in the defaults of the model, that were not being read in the `timeseries` plot. I tested it with all the examples of the docs, and it seems to look exactly like what we have in `main`.
Pablo

Requested reviewers based on the meeting today.