### PR TITLE
Hotfixes v2

### DIFF
--- a/melodies_monet/driver.py
+++ b/melodies_monet/driver.py
@@ -2733,6 +2733,8 @@ class analysis:
                                     "domain_type": domain_type,
                                     "domain_name": domain_name,
                                     "vdiff": grp_dict["data_proc"].get("vdiff", None),
+                                    "vmax": grp_dict["data_proc"].get("vmax", None),
+                                    "vmin": grp_dict["data_proc"].get("vmin", None),
                                     "nlevels": grp_dict["data_proc"].get("nlevels", None),
                                     "fig_dict": fig_dict,
                                     "text_dict": text_dict,

--- a/melodies_monet/plots/satplots.py
+++ b/melodies_monet/plots/satplots.py
@@ -670,7 +670,7 @@ def make_boxplot(comb_bx, label_bx, ylabel = None, vmin = None, vmax = None, out
     savefig(outname + '.png',loc=4, logo_height=100, bbox_inches='tight', dpi=200)
     
 def make_spatial_bias_gridded(df, column_o=None, label_o=None, column_m=None, 
-                      label_m=None, ylabel = None, vmin=None,
+                      label_m=None, ylabel = None, vmin=None, vdiff=None,
                       vmax = None, nlevels = None, proj = None, outname = 'plot', 
                       domain_type=None, domain_name=None, fig_dict=None, 
                       text_dict=None,debug=False):
@@ -733,10 +733,13 @@ def make_spatial_bias_gridded(df, column_o=None, label_o=None, column_m=None,
         map_kwargs['crs'] = proj
     
     #First determine colorbar
-    if vmin is None and vmax is None:
+    if vmin is None and vmax is None and vdiff is None:
         #vmin = vmodel_mean.quantile(0.01)
         vmax = np.max((np.abs(diff_mod_min_obs.quantile(0.99)),np.abs(diff_mod_min_obs.quantile(0.01))))
         vmin = -vmax
+    if vdiff is not None:
+        vmax = np.float64(vdiff)
+        vmin = -np.float64(vdiff)
         
     if nlevels is None:
         nlevels = 21
@@ -746,9 +749,12 @@ def make_spatial_bias_gridded(df, column_o=None, label_o=None, column_m=None,
     norm = mpl.colors.BoundaryNorm(clevel, ncolors=cmap.N, clip=False)
         
     #I add extend='both' here because the colorbar is setup to plot the values outside the range
-    ax = monet.plots.mapgen.draw_map(crs=map_kwargs['crs'],extent=map_kwargs['extent'])
+    states = fig_dict.get('states', True)
+    counties = fig_dict.get('counties', False)
+    ax = monet.plots.mapgen.draw_map(crs=map_kwargs['crs'],extent=map_kwargs['extent'], states=states, counties=counties)
     # draw scatter plot of model and satellite differences
-    c = ax.axes.scatter(df.longitude,df.latitude,c=diff_mod_min_obs,cmap=cmap,s=2,norm=norm)
+    markersize = fig_dict.get('markersize', 2)
+    c = ax.axes.scatter(df.longitude,df.latitude,c=diff_mod_min_obs,cmap=cmap,s=markersize,norm=norm)
     plt.gcf().canvas.draw() 
     plt.tight_layout(pad=0)
     plt.title(title_add + label_m + ' - ' + label_o,fontweight='bold',**text_kwargs)

--- a/melodies_monet/plots/satplots.py
+++ b/melodies_monet/plots/satplots.py
@@ -749,7 +749,7 @@ def make_spatial_bias_gridded(df, column_o=None, label_o=None, column_m=None,
     norm = mpl.colors.BoundaryNorm(clevel, ncolors=cmap.N, clip=False)
         
     #I add extend='both' here because the colorbar is setup to plot the values outside the range
-    states = fig_dict.get('states', True)
+    states = fig_dict.get('states', False)
     counties = fig_dict.get('counties', False)
     ax = monet.plots.mapgen.draw_map(crs=map_kwargs['crs'],extent=map_kwargs['extent'], states=states, counties=counties)
     # draw scatter plot of model and satellite differences

--- a/melodies_monet/plots/surfplots.py
+++ b/melodies_monet/plots/surfplots.py
@@ -825,7 +825,7 @@ def make_spatial_overlay(df, vmodel, column_o=None, label_o=None, column_m=None,
     elif domain_type.startswith('custom:') or domain_type.startswith('auto-region:'):
         valid_data = vmodel.notnull()
         lons = vmodel.longitude.where(valid_data)
-        lats = vmodel.latitutde.where(valid_data)
+        lats = vmodel.latitude.where(valid_data)
         latmin, lonmin, latmax, lonmax = lats.min(), lons.min(), lats.max(), lons.max()
         title_add = domain_name + ': '
     else:

--- a/melodies_monet/plots/xarray_plots.py
+++ b/melodies_monet/plots/xarray_plots.py
@@ -783,6 +783,7 @@ def make_spatial_bias_gridded(
     fig_dict=None,
     text_dict=None,
     debug=False,
+    **kwargs
 ):
     """Creates difference plot for satellite and model data.
     For data in swath format, overplots all differences


### PR DESCRIPTION
Hotfixes v1 had introduced a bug in satplots, which I did not notice. It was breaking make_spatial_bias_gridded by adding vdiff.
On the other hand, make_spatial_bias_gridded 
Since vdiff is what we are using in other (surfplots, xarray_plots, etc), I added it as an optional variable.
This shouldn't change the default behaviour.
Pablo