### PR TITLE
Update MONET and MONETIO versions listed on docs

### DIFF
--- a/docs/applications/publications.rst
+++ b/docs/applications/publications.rst
@@ -10,7 +10,7 @@ MONET version 1.0 (which included what is now MONETIO) development is described 
   Toolkit (MONET) Version 1.0 for Evaluating Atmospheric Transport Models, Atmosphere, 8, 
   no. 11, 210, https://doi.org/10.3390/atmos8110210, 2017.
 
-MELODIES MONET version 1, MONET version 2, and MONETIO version 0.2 development are described in the following papers:
+MELODIES MONET version 1.0, MONET version 2.3.0, and MONETIO version 0.3.0 development are described in the following papers:
 
 * A paper describing surface and aircraft capabilities is in preparation.
 


### PR DESCRIPTION
Update MONET and MONETIO versions on ReadTheDocs to be consistent with the latest conda releases on the publications page:
You can see these version numbers under the conda-forge label at the repositories below.
https://github.com/noaa-oar-arl/monet/tree/stable
https://github.com/noaa-oar-arl/monetio/tree/stable


