### PR TITLE
Code fix to driver.py 

### DIFF
--- a/melodies_monet/driver.py
+++ b/melodies_monet/driver.py
@@ -492,17 +492,20 @@ class model:
         from . import tutorial
 
         print(self.file_str)
-        if self.file_str.startswith("example:"):
+        if isinstance(self.file_str, list):
+            self.files = self.file_str # we assume the given list is already sorted
+        elif self.file_str.startswith("example:"):
             example_id = ":".join(s.strip() for s in self.file_str.split(":")[1:])
             self.files = [tutorial.fetch_example(example_id)]
         else:
             self.files = sort(glob(self.file_str))
             
         # add option to read list of files from text file
-        _, extension = os.path.splitext(self.file_str)
-        if extension.lower() == '.txt':
-            with open(self.file_str,'r') as f:
-                self.files = f.read().split()
+        if not isinstance(self.file_str, list):
+            _, extension = os.path.splitext(self.file_str)
+            if extension.lower() == '.txt':
+                with open(self.file_str,'r') as f:
+                    self.files = f.read().split()
 
         if self.file_vert_str is not None:
             self.files_vert = sort(glob(self.file_vert_str))
@@ -961,8 +964,12 @@ class analysis:
                     m.mod_kwargs = self.control_dict['model'][mod]['mod_kwargs']    
                 m.label = mod
                 # create file string (note this can include hot strings)
-                m.file_str = os.path.expandvars(
-                    self.control_dict['model'][mod]['files'])
+                if isinstance(self.control_dict['model'][mod]['files'], list):
+                    m.file_str = [
+                        os.path.expandvars(f) for f in self.control_dict['model'][mod]['files']
+                    ]
+                else:
+                    m.file_str = os.path.expandvars(self.control_dict['model'][mod]['files'])
                 if 'files_vert' in self.control_dict['model'][mod].keys():
                     m.file_vert_str = os.path.expandvars(
                         self.control_dict['model'][mod]['files_vert'])

--- a/melodies_monet/driver.py
+++ b/melodies_monet/driver.py
@@ -493,7 +493,7 @@ class model:
 
         print(self.file_str)
         if isinstance(self.file_str, list):
-            self.files = self.file_str # we assume the given list is already sorted
+            self.files = sorted(self.file_str)
         elif self.file_str.startswith("example:"):
             example_id = ":".join(s.strip() for s in self.file_str.split(":")[1:])
             self.files = [tutorial.fetch_example(example_id)]


### PR DESCRIPTION
I added in a code fix to driver.py to be able to read in a list of multiple sorted model output files from the YAML file. 

Essentially, when reading the files from the YAML file, there are four different scenarios: 
1. If given a sorted list, assigns this list to self.files variable (change I added)
2. If the string begins with 'example', it treats the input as an ID and fetches example files. 
3. If file path uses (*), then pulls files matching the pattern using glob and sorts.
4. Checks for .txt files.

The last code change reads the list of model files given and prepares them for use in MELODIES-MONET. 