### PR TITLE
Added the chimere model, and fixed a minor bug

### DIFF
--- a/melodies_monet/driver.py
+++ b/melodies_monet/driver.py
@@ -569,6 +569,13 @@ class model:
             print('**** Reading WRF-Chem model output...')
             self.mod_kwargs.update({'var_list' : list_input_var})
             self.obj = mio.models._wrfchem_mm.open_mfdataset(self.files,**self.mod_kwargs)
+        elif 'chimere' in self.model.lower():
+            print('**** Reading Chimere model output...')
+            self.mod_kwargs.update({
+                                    'var_list': list_input_var,
+                                    "surf_only": control_dict['model'][self.label].get('surf_only', False)
+                                    })
+            self.obj = mio.models.chimere.open_mfdataset(self.files, **self.mod_kwargs)
         elif any([mod_type in self.model.lower() for mod_type in ('ufs', 'rrfs')]):
             print('**** Reading UFS-AQM model output...')
             if 'rrfs' in self.model.lower():
@@ -890,7 +897,6 @@ class analysis:
                         else:
                             write_analysis_ncf(obj=getattr(self,attr), output_dir=self.output_dir_save, 
                                                keep_groups=self.save[attr]['data'])
-        
     def read_analysis(self):
         """Read all previously saved analysis attributes listed in analysis section of input yaml file.
 

--- a/melodies_monet/plots/surfplots.py
+++ b/melodies_monet/plots/surfplots.py
@@ -824,8 +824,8 @@ def make_spatial_overlay(df, vmodel, column_o=None, label_o=None, column_m=None,
         title_add = 'EPA Region ' + domain_name + ': '
     elif domain_type.startswith('custom:') or domain_type.startswith('auto-region:'):
         valid_data = vmodel.notnull()
-        lons = vmodel.longitude.where(valid_data)
-        lats = vmodel.latitude.where(valid_data)
+        lons = vmodel.where(valid_data).longitude
+        lats = vmodel.where(valid_data).latitude
         latmin, lonmin, latmax, lonmax = lats.min(), lons.min(), lats.max(), lons.max()
         title_add = domain_name + ': '
     else:


### PR DESCRIPTION
Added the chimere model adapter that i also pull request'ed to monetio.
Fixed a minor bug in border definition for spatial_overlay graphs. 
Might need to confirm that it was non intended behaviour but when making custom polygons for data filtering and creating a spatial_overlay graph an error occured where a float was expected but an xarray.dataarray (or dataset can't recall now) was provided.
You can check that in other if-statements around the fix the values are set to floats (like when the borders are provided for CONUS or EPA regions)
I just changed the order of the operations so it actually provides the minlat, minlon, ... for the vmodel data.