### PR TITLE
HERA fix to link_cartopy_files.sh Cartopy shp files now on Ursa/Hera

### DIFF
--- a/python_env_ymls/hera/link_cartopy_files.sh
+++ b/python_env_ymls/hera/link_cartopy_files.sh
@@ -12,7 +12,7 @@
 
 # Location of Natural Earth shapefiles
 # Directory structure: {res}_{cultural,physical} e.g. '110m_physical'
-src_base=/scratch1/RDARCH/rda-arl-gpu/Barry.Baker/emissions/nexus/cartopy_shapefiles
+src_base=/scratch4/BMC/rcm1/qrasool/cartopy_shapefiles ##/scratch1/RDARCH/rda-arl-gpu/Barry.Baker/emissions/nexus/cartopy_shapefiles
 
 # Cartopy user data dir, where cartopy checks for shapefiles by default
 cartopy_data_dir=~/.local/share/cartopy


### PR DESCRIPTION
I re-download these on my end on scratch[3,4] accessible via Hera/Ursa. 

 I have downloaded them here: /scratch4/BMC/rcm1/qrasool/cartopy_shapefiles/

The source i used is: https://www.naturalearthdata.com/downloads/
