### PR TITLE
Satellite filtering

### DIFF
--- a/melodies_monet/driver.py
+++ b/melodies_monet/driver.py
@@ -312,6 +312,10 @@ class observation:
         except ValueError as e:
             print('something happened opening file:', e)
             return
+        from .util.tools_sat import mask_and_scale_sat, sum_variables_sat, filter_obs_sat
+        filter_obs_sat(self)
+        sum_variables_sat(self)
+        mask_and_scale_sat(self)
 
     def filter_obs(self):
         """Filter observations based on filter_dict.

--- a/melodies_monet/util/tools_sat.py
+++ b/melodies_monet/util/tools_sat.py
@@ -1,0 +1,138 @@
+import xarray as xr
+from melodies_monet.driver import observation
+
+
+def mask_and_scale_sat(obs):
+    """Applies masking and scaling to satellite observation data.
+    It opperates separately if the data is a dictionary or
+    xarrray.Dataset. It acts in place
+
+    Parameters
+    ----------
+    obs : driver.observation
+        The observation object containing satellite data.
+
+    Returns
+    -------
+    None
+        The function modifies the observation data in place.
+
+    Raises
+    ------
+    TypeError
+        If obs.obj is neither an xarray.Dataset nor a dictionary of xarray.Datasets.
+    """
+    if isinstance(obs.obj, xr.Dataset):
+        obs.mask_and_scale()
+    elif isinstance(obs.obj, dict):
+        for key in obs.obj:
+            obs_tmp = observation()
+            obs_tmp.obj = obs.obj[key]
+            obs_tmp.variable_dict = obs.variable_dict.copy()
+            if isinstance(obs_tmp.obj, list):
+                new_list = []
+                for item in obs_tmp.obj:
+                    obs_item = observation()
+                    obs_item.obj = item
+                    obs_item.variable_dict = obs_tmp.variable_dict.copy()
+                    obs_item.mask_and_scale()
+                    new_list.append(obs_item.obj)
+                obs_tmp.obj = new_list
+            else:
+                obs_tmp.mask_and_scale()
+                obs.obj[key] = obs_tmp.obj
+    else:
+        raise TypeError("obs.obj must be either an xarray.Dataset or a dict of xarray.Datasets.")
+
+
+def sum_variables_sat(obs):
+    """Sum any variables noted that should be summed to create new variables.
+    This occurs after any unit scaling. It opperates separately if the data 
+    is a dictionary or xarrray.Dataset. It acts in place.
+
+    Parameters
+    ----------
+    obs : driver.observation
+        The observation object containing satellite data.
+
+    Returns
+    -------
+    None
+        The function modifies the observation data in place.
+
+    Raises
+    ------
+    TypeError
+        If obs.obj is neither an xarray.Dataset nor a dictionary of xarray.Datasets.
+    """
+    if obs.variable_summing is None:
+        return
+    if isinstance(obs.obj, xr.Dataset):
+        obs.sum_variables()
+    elif isinstance(obs.obj, dict):
+        for key in obs.obj:
+            obs_tmp = observation()
+            obs_tmp.obj = obs.obj[key]
+            obs_tmp.variable_dict = obs.variable_dict.copy()
+            obs_tmp.variable_summing = obs.variable_summing.copy()
+            if isinstance(obs_tmp.obj, list):
+                new_list = []
+                for item in obs_tmp.obj:
+                    obs_item = observation()
+                    obs_item.obj = item
+                    obs_item.variable_dict = obs_tmp.variable_dict.copy()
+                    obs_item.variable_summing = obs_tmp.variable_summing.copy()
+                    obs_item.sum_variables()
+                    new_list.append(obs_item.obj)
+                obs_tmp.obj = new_list
+            else:
+                obs_tmp.sum_variables()
+                obs.obj[key] = obs_tmp.obj
+    else:
+        raise TypeError("obs.obj must be either an xarray.Dataset or a dict of xarray.Datasets.")
+
+
+def filter_obs_sat(obs):
+    """Filter observations based on filter_dict. It opperates separately
+    if the data is a dictionary or xarrray.Dataset. It acts in place.
+
+    Parameters
+    ----------
+    obs : driver.observation
+        The observation object containing satellite data.
+
+    Returns
+    -------
+    None
+        The function modifies the observation data in place.
+
+    Raises
+    ------
+    TypeError
+        If obs.obj is neither an xarray.Dataset nor a dictionary of xarray.Datasets.
+    """
+    if obs.data_proc is None or 'filter_dict' not in obs.data_proc:
+        return
+    if isinstance(obs.obj, xr.Dataset):
+        obs.filter_obs()
+    elif isinstance(obs.obj, dict):
+        for key in obs.obj:
+            obs_tmp = observation()
+            obs_tmp.obj = obs.obj[key]
+            obs_tmp.variable_dict = obs.variable_dict.copy()
+            obs_tmp.data_proc = obs.data_proc.copy()
+            if isinstance(obs_tmp.obj, list):
+                new_list = []
+                for item in obs_tmp.obj:
+                    obs_item = observation()
+                    obs_item.obj = item
+                    obs_item.variable_dict = obs_tmp.variable_dict.copy()
+                    obs_item.data_proc = obs_tmp.data_proc.copy()
+                    obs_item.filter_obs(drop=False)
+                    new_list.append(obs_item.obj)
+                obs_tmp.obj = new_list
+            else:
+                obs_tmp.filter_obs(drop=False)
+                obs.obj[key] = obs_tmp.obj
+    else:
+        raise TypeError("obs.obj must be either an xarray.Dataset or a dict of xarray.Datasets.")


### PR DESCRIPTION
This adds the filtering capabilities for satellite data. I. e., it just takes our existing methods and iterates them over a dict, if needed.

There are a few simple steps that would make it better for version 2, as well as more flexible:

a) We could just have all of this methods as functions in the tool. This way, our filtering, masking, etc., would work for both satellite and surface, which would help us move in a Do Not Repeat Yourself direction and make life considerably easier.

b) If we move out of dicts for satellites, we _might_ be able to call our methods directly. Seems like a long shot, though.

Cheers
Pablo