### PR TITLE
Read vmin_plot and vmax_plot

### DIFF
--- a/examples/yaml/control_tempo_l2_hcho.yaml
+++ b/examples/yaml/control_tempo_l2_hcho.yaml
@@ -102,8 +102,8 @@ plots:
     data: ['tempo_l2_hcho_wrfchem_v4.2']
     data_proc:
       set_axis: True
-      vmax: 1e16
-      vmin: 0
+      vmax_plot: 1e16
+      vmin_plot: 0
 
   plot_grp4:
     type: 'taylor'

--- a/examples/yaml/control_tempo_l2_no2.yaml
+++ b/examples/yaml/control_tempo_l2_no2.yaml
@@ -102,8 +102,8 @@ plots:
     data: ['tempo_l2_no2_wrfchem_v4.2']
     data_proc:
       set_axis: True
-      vmax: 1e15
-      vmin: 0
+      vmax_plot: 1e15
+      vmin_plot: 0
 
   plot_grp4:
     type: 'taylor'

--- a/melodies_monet/driver.py
+++ b/melodies_monet/driver.py
@@ -1902,8 +1902,8 @@ class analysis:
                                     vmin = None
                                     vmax = None
                             else:
-                                vmin = None
-                                vmax = None
+                                vmin = grp_dict.get('data_proc', {}).get('vmin_plot', None)
+                                vmax = grp_dict.get('data_proc', {}).get('vmax_plot', None)
                             # Select time to use as index.
 
                             # 2024-03-01 MEB needs to only apply if pandas. fails for xarray
@@ -2711,7 +2711,9 @@ class analysis:
                                     print('Warning: vdiff_plot not specified for ' + obsvar + ', so default used.')
                                     vdiff = None
                             else:
-                                vdiff = None
+                                vdiff = grp_dict.get('data_proc', {}).get('vdiff_plot', None)
+                                vmax = grp_dict.get('data_proc', {}).get('vmin_plot', None)
+                                vmin = grp_dict.get('data_proc', {}).get('vmax_plot', None)
                             # p_label needs to be added to the outname for this plot
                             outname = "{}.{}".format(outname, p_label)
                             splots.make_spatial_bias(
@@ -2751,9 +2753,9 @@ class analysis:
                                     "outname": outname,
                                     "domain_type": domain_type,
                                     "domain_name": domain_name,
-                                    "vdiff": grp_dict["data_proc"].get("vdiff", None),
-                                    "vmax": grp_dict["data_proc"].get("vmax", None),
-                                    "vmin": grp_dict["data_proc"].get("vmin", None),
+                                    "vdiff": vdiff,
+                                    "vmax": vmax,
+                                    "vmin": vmin,
                                     "nlevels": grp_dict["data_proc"].get("nlevels", None),
                                     "fig_dict": fig_dict,
                                     "text_dict": text_dict,
@@ -2772,16 +2774,19 @@ class analysis:
                                 "ylabel": use_ylabel,
                                 "domain_type": domain_type,
                                 "domain_name": domain_name,
-                                "vmax": grp_dict["data_proc"].get("vmax", None),
-                                "vmin": grp_dict["data_proc"].get("vmin", None),
+                                "vdiff": vdiff,
+                                "vmax": vmax,
+                                "vmin": vmin,
                                 "fig_dict": fig_dict,
                                 "text_dict": text_dict,
                                 "debug": self.debug,
                             }
-                            if isinstance(plot_kwargs["vmax"], str):
-                                plot_kwargs["vmax"] = float(plot_kwargs["vmax"])
+                            if isinstance(plot_kwargs["vdiff"], str):
+                                plot_kwargs["vdiff"] = float(plot_kwargs["vdiff"])
                             if isinstance(plot_kwargs["vmin"], str):
                                 plot_kwargs["vmin"] = float(plot_kwargs["vmin"])
+                            if isinstance(plot_kwargs["vmax"], str):
+                                plot_kwargs["vmax"] = float(plot_kwargs["vmax"])
                             xrplots.make_spatial_dist(**plot_kwargs)
                             plot_kwargs["varname"] = modvar
                             plot_kwargs["label"] = p.model
@@ -2835,9 +2840,9 @@ class analysis:
                                     vmax = None
                                     nlevels = None
                             else:
-                                vmin = None
-                                vmax = None
-                                nlevels = None
+                                vmin = grp_dict.get("data_proc", {}).get("vmin_plot", None)
+                                vmin = grp_dict.get("data_proc", {}).get("vmax_plot", None)
+                                nlevels = grp_dict.get("data_proc", {}).get("nlevels", None)
                             #Check if z dim is larger than 1. If so select, the first level as all models read through 
                             #MONETIO will be reordered such that the first level is the level nearest to the surface.
                             # Create model slice and select time window for spatial plots


### PR DESCRIPTION
This PR fixes the fact that vmin_plot and vmax_plot were often not read by the driver, especially if they were written in data_proc in the plots, which was inconsistent.

There is, however, one breaking change: spatial_dist was reading vmax and vmin. That was an inconsistency, so I believe that doing this breaking change is justifiable in this case.
Cheers
Pablo 