### PR TITLE
Refactor std-to-ambient conversion and backward-compatible wrappers

### DIFF
--- a/melodies_monet/util/tools.py
+++ b/melodies_monet/util/tools.py
@@ -483,7 +483,6 @@ def convert_std_to_amb(
 ):
     """
     Convert aerosol concentrations from standard to ambient conditions.
-    This function applies a conversion factor based on the ratio of ambient
     air quality number density to std air number density using the ideal gas law.
     
     Parameter

--- a/melodies_monet/util/tools.py
+++ b/melodies_monet/util/tools.py
@@ -482,7 +482,7 @@ def convert_std_to_amb(
     standard_temperature=273.0
 ):
     """
-    Convert concentration from std to amb conditions.
+    Convert aerosol concentrations from standard to ambient conditions.
     This function applies a conversion factor based on the ratio of ambient
     air quality number density to std air number density using the ideal gas law.
     

--- a/melodies_monet/util/tools.py
+++ b/melodies_monet/util/tools.py
@@ -486,26 +486,21 @@ def convert_std_to_amb(
     
     Parameters
     ----------
-    :param ds: xarray.Dataset
+    ds: xarray.Dataset
         Dataset containing variables to convert.
-    :param convert_vars: list of str, optional
+    convert_vars: list of str, optional
         List of variable names in ds to apply conversion to.
-    :param temp_var: str
+    temp_var: str
         Name of temperature variable in ds (units must be Kelvin).
-    :param pres_var: str
+    pres_var: str
         Name of pressure variable in ds (units must be Pascal).
-    :param standard_pressure: float, optional
+    standard_pressure: float, optional
         Standard pressure in Pa used for defining standard conditions.
         Default is 101325 Pa (international standard atmosphere).
-    :param standard_temperature: float, optional
+    standard_temperature: float, optional
         Standard temperature in K used for defining standard conditions.
         Default is 273 K.
     
-    PLease note:
-    P = Pressure
-    T = temperature
-    N_A = Avogadro's number
-    R  = Universal gas constant
     """
     if convert_vars is None:
         convert_vars = []

--- a/melodies_monet/util/tools.py
+++ b/melodies_monet/util/tools.py
@@ -483,7 +483,6 @@ def convert_std_to_amb(
 ):
     """
     Convert aerosol concentrations from standard to ambient conditions.
-    air quality number density to std air number density using the ideal gas law.
     
     Parameter
     ---

--- a/melodies_monet/util/tools.py
+++ b/melodies_monet/util/tools.py
@@ -534,7 +534,7 @@ def convert_std_to_amb_ams(ds, convert_vars=None, temp_var=None, pres_var=None):
 def convert_std_to_amb_bc(ds, convert_vars=None, temp_var=None, pres_var=None):
     """
     Backwards compatable wrapper for AMS Dataset.
-    This uses legacy aircraft processing standard
+    This uses black carbon aircraft processing standard
     Presure = 101300 Pa
     Temperature = 273 K
     """

--- a/melodies_monet/util/tools.py
+++ b/melodies_monet/util/tools.py
@@ -484,7 +484,7 @@ def convert_std_to_amb(
     """
     Convert aerosol concentrations from standard to ambient conditions.
     
-    Parameter
+    Parameters
     ---
     :param ds: xarray.Dataset
         Dataset containing variables to convert.

--- a/melodies_monet/util/tools.py
+++ b/melodies_monet/util/tools.py
@@ -473,46 +473,87 @@ def loop_pairing(control,file_pairs_yaml='',file_pairs={},save_types=['paired'])
         an.pair_data()
         an.save_analysis()
 
-def convert_std_to_amb_ams(ds,convert_vars=[],temp_var=None,pres_var=None):
+def convert_std_to_amb(
+    ds,
+    convert_vars=None,
+    temp_var=None,
+    pres_var=None,
+    standard_pressure=101325.0,
+    standard_temperature=273.0
+):
+    """
+    Convert concentration from std to amb conditions.
+    This function applies a conversion factor based on the ratio of ambient
+    air quality number density to std air number density using the ideal gas law.
     
-    # Convert variables from std to amb
+    Parameter
+    ---
+    :param ds: xarray.Dataset
+        Dataset containing variables to convert.
+    :param convert_vars: list of str, optional
+        List of variable names in ds to apply conversion to.
+    :param temp_var: str
+        Name of temperature variable in ds (units must be Kelvin).
+    :param pres_var: str
+        Name of pressure variable in ds (units must be Pascal).
+    :param standard_pressure: float, optional
+        Standard pressure in Pa used for defining standard conditions.
+        Default is 101325 Pa (international standard atmosphere).
+    :param standard_temperature: float, optional
+        Standard temperature in K used for defining standard conditions.
+        Default is 273 K.
     
-    # Units of temp_var must be K
-    # Units of pres_var must be Pa 
-    
-    #So I just need to convert the obs from std to amb.
-    # Losch = 2.69e25 # loschmidt's number
-    #I checked the more detailed icart files
-    #273 K, 1 ATM (101325 Pa)
-    std_ams = 101325.*N_A/(R*273.)
-    #use pressure_obs now, which is in pa
-    Airnum = ds[pres_var]*N_A/(R*ds[temp_var])
-    
-    # amb to std = Losch / Airnum
-    convert_std_to_amb_ams = Airnum/std_ams
-    
-    for var in convert_vars:
-        ds[var] = ds[var]*convert_std_to_amb_ams
+    PLease note:
+    P = Pressure
+    T = temperature
+    N_A = Avogadro's number
+    R  = Universal gas constant
+    """
+    if convert_vars is None:
+        convert_vars = []
 
-def convert_std_to_amb_bc(ds,convert_vars=[],temp_var=None,pres_var=None):
-    
-    # Convert variables from std to amb
-    
-    # Units of temp_var must be K
-    # Units of pres_var must be Pa 
-    
-    #So I just need to convert the obs from std to amb.
-    # Losch = 2.69e25 # loschmidt's number
-    #1013 mb, 273 K (101300 Pa)
-    std_bc = 101300.*N_A/(R*273.)
-    #use pressure_obs now, which is in pa
-    Airnum = ds[pres_var]*N_A/(R*ds[temp_var])
-    
-    # amb to std = Losch / Airnum
-    convert_std_to_amb_bc = Airnum/std_bc
-    
+    std_air = standard_pressure * N_A / (R * standard_temperature)
+    Airnum = ds[pres_var] * N_A / (R * ds[temp_var])
+    factor = Airnum / std_air
+
     for var in convert_vars:
-        ds[var] = ds[var]*convert_std_to_amb_bc
+        ds[var] = ds[var] * factor
+
+
+
+def convert_std_to_amb_ams(ds, convert_vars=None, temp_var=None, pres_var=None):
+    """ 
+    Backwards compatable wrapper for AMS Dataset.
+    This uses international std atmosphere defination
+    Pressure = 101325 Pa
+    Temperature = 273 K
+    """
+    return convert_std_to_amb(
+        ds,
+        convert_vars=convert_vars,
+        temp_var=temp_var,
+        pres_var=pres_var,
+        standard_pressure=101325.0,
+        standard_temperature=273.0
+    )
+
+
+def convert_std_to_amb_bc(ds, convert_vars=None, temp_var=None, pres_var=None):
+    """
+    Backwards compatable wrapper for AMS Dataset.
+    This uses legacy aircraft processing standard
+    Presure = 101300 Pa
+    Temperature = 273 K
+    """
+    return convert_std_to_amb(
+        ds,
+        convert_vars=convert_vars,
+        temp_var=temp_var,
+        pres_var=pres_var,
+        standard_pressure=101300.0,
+        standard_temperature=273.0
+    )
+
 
 
 def calc_partialcolumn(modobj, var="NO2"):

--- a/melodies_monet/util/tools.py
+++ b/melodies_monet/util/tools.py
@@ -485,7 +485,7 @@ def convert_std_to_amb(
     Convert aerosol concentrations from standard to ambient conditions.
     
     Parameters
-    ---
+    ----------
     :param ds: xarray.Dataset
         Dataset containing variables to convert.
     :param convert_vars: list of str, optional


### PR DESCRIPTION

This PR refactors the standard-to-ambient conversion logic by consolidating it into a single configurable function. The existing AMS and BC conversion functions are retained as lightweight wrappers, so there are no breaking changes to current workflows or datasets.


Changes Done:
1.Introduced a new configurable convert_std_to_amb() function to handle standard-to-ambient conversions.
2.Updated AMS and BC conversion functions to call the new shared implementation.
3.Removed duplicated logic across conversion functions.
4.Preserved compatibility with existing aircraft datasets.


Please Note: I have validated functionality using synthetic datasets and verified mathematical correctness. I have not yet tested with full aircraft campaign datasets, but since AMS and BC wrappers preserve original constants, behavior should remain unchanged. I am happy to help test with aircraft datasets if sample data or workflow guidance is available.

Screenshot/Output
<img width="2880" height="1704" alt="Screenshot 2026-02-13 223101" src="https://github.com/user-attachments/assets/ae929140-8b57-4813-a248-78acb3fb1add" />

This PR tries to fix issue #333  