### PR TITLE
Fix bug in looking for the new tempo reader

### DIFF
--- a/melodies_monet/driver/_observation.py
+++ b/melodies_monet/driver/_observation.py
@@ -287,7 +287,7 @@ class observation:
             elif "tempo_l2" in self.sat_type:
                 print("Reading TEMPO L2")
                 try:
-                    self.obj = mio.sat.tempo_l2_no2.open_dataset(
+                    self.obj = mio.sat.tempo_l2.open_dataset(
                         self.file, self.variable_dict, debug=self.debug
                     )
                 except AttributeError:


### PR DESCRIPTION
The name of the new reader was wrong (it included an _no2 that is not there). I don't know how I missed it.
CHeers
Pablo