### PR TITLE
ENH: Adapt model rename_vars for cfgrib conventions

### DIFF
--- a/melodies_monet/driver.py
+++ b/melodies_monet/driver.py
@@ -652,6 +652,8 @@ class model:
                     if 'rename' in d:
                         self.obj = self.obj.rename({v:d['rename']})
                         self.variable_dict[d['rename']] = self.variable_dict.pop(v)
+        if "valid_time" in self.obj.dims:
+            self.obj = self.obj.rename(valid_time="time")
 
     def mask_and_scale(self):
         """Mask and scale model data including unit conversions.


### PR DESCRIPTION
cfgrib names the valid time variable `valid_time`, where this seems to expect the pynio default, which seems to be `time`.  This sets the variable name to conform to expectations.

(cfgrib also has a "time" variable, used for the forecast reference/initialization time)