### PR TITLE
CESM-FV satellite: Fix cesm_fv surf_only forwarding and mod_to_overpass attribute read

### DIFF
--- a/examples/yaml/control_tempo_l2_hcho_cesm_se.yaml
+++ b/examples/yaml/control_tempo_l2_hcho_cesm_se.yaml
@@ -1,0 +1,107 @@
+#-------------------------------------------------------------------
+# MELODIES-MONET test: TEMPO L2 HCHO vs CESM-fv/CAM-chem 
+# updated 06/15/2026 L.T.   
+
+# works with monetio: https://github.com/noaa-oar-arl/monetio - 0.3.2
+# works with (soon to be) melodies-monet v1.1: https://github.com/NCAR/MELODIES-MONET/tree/develop
+
+# works: https://github.com/L12D2/mm_uxarray/tree/backup/asia-aq-satellite-wip/docs/examples/ungridded_support/unstructured_grid_read_uxarray/tropomi_testing/works
+#-------------------------------------------------------------------
+
+analysis:
+  start_time: '2024-06-30'                 #UTC  
+  end_time:   '2024-06-30 23:59:00'        #UTC
+  output_dir: ./output_hcho
+  output_dir_save: ./output_hcho
+  output_dir_read: ./output_hcho
+  save:
+    paired: {method: 'netcdf', prefix: '20240101', data: all}
+  read:
+    paired:
+      method: 'netcdf'
+      filenames:
+        tempo_l2_hcho_cam-chem-se: ['./output_hcho/20240101_tempo_l2_hcho_cam-chem-se.nc4']
+  debug: false
+
+obs:
+  tempo_l2_hcho:
+    regrid_method: nearest_s2d
+    debug: false
+    filename: /glade/campaign/acom/acom-da/sma/TEMPO_HCHO_V03/TEMPO_HCHO_L2_V03_20240630T*_S0*
+    obs_type: sat_swath_clm
+    sat_type: tempo_l2_hcho
+    variables:
+      main_data_quality_flag:
+        main_data_quality_flag_max: 0
+        var_applied: ['vertical_column']
+      vertical_column:                 # HCHO total column (molecules/cm^2)
+        ylabel_plot: 'HCHO column'
+        vmin_plot: 0
+        vmax_plot: 2.0e+16
+      pressure: {}
+      #tropopause_pressure: {}
+      scattering_weights: {}
+      amf: {}
+      
+model:
+  cam-chem-se:
+    files: 
+      - /glade/derecho/scratch/gaubert/tempo/f.e22.FCnudged.ne0CONUSne30x8_ne0CONUSne30x8_mt12.ref_dust_M1.001/f.e22.FCnudged.01x01.ref_dust_M1.001.cam.h1.2024-06-30-03600.nc
+    mod_type: 'cesm_fv' 
+    mapping:
+      tempo_l2_hcho:
+        CH2O: "vertical_column"        
+    projection: ~
+    mod_kwargs:
+      convert_to_ppb: True
+      surf_only: false
+    plot_kwargs: {color: 'purple', marker: '^', linestyle: 'dotted'}
+
+plots:
+  plot_grp1:
+    type: 'timeseries'
+    fig_kwargs: {figsize: [12, 6]}
+    default_plot_kwargs: {linewidth: 2.0, markersize: 10.}
+    text_kwargs: {fontsize: 18.}
+    domain_type: ["all"]
+    domain_name: ["CONUS"]
+    data: ["tempo_l2_hcho_cam-chem-se"]
+    data_proc:
+      ts_offset: (-4, 'h')
+      ts_avg_window: 'h'
+      set_axis: true
+
+  plot_grp2:
+    type: 'gridded_spatial_bias'
+    fig_kwargs: {states: true, counties: false}
+    text_kwargs: {fontsize: 16}
+    domain_type: ['all', 'all']
+    domain_name: ['CONUS', 'model']
+    data: ['tempo_l2_hcho_cam-chem-se']
+    data_proc: {set_axis: true}
+
+  plot_grp3:
+    type: 'spatial_dist'
+    fig_kwargs: {states: true, counties: false}
+    text_kwargs: {fontsize: 16}
+    domain_type: ['all', 'all']
+    domain_name: ['CONUS', 'model']
+    data: ['tempo_l2_hcho_cam-chem-se']
+    data_proc: {set_axis: true, vmax: 2e16, vmin: 0}
+
+  plot_grp5:
+    type: 'taylor'
+    data: ['tempo_l2_hcho_cam-chem-se']
+    domain_type: ['all']
+    domain_name: ['CONUS']
+    data_proc: {set_axis: true, ty_scale: 1.5}
+    default_plot_kwargs: {markersize: 10., marker: 's'}
+
+stats:
+  stat_list: ["MB", "MdnB", "R2", "RMSE"]
+  round_output: 2
+  output_table: False
+  domain_type: ["all"]
+  domain_name: ["CONUS"]
+  data: ['tempo_l2_hcho_cam-chem-se']
+  

--- a/examples/yaml/control_tempo_l2_no2_cesm_se.yaml
+++ b/examples/yaml/control_tempo_l2_no2_cesm_se.yaml
@@ -1,0 +1,113 @@
+#-------------------------------------------------------------------
+# MELODIES-MONET test: TEMPO L2 NO2 vs CESM-fv/CAM-chem 
+# updated 06/15/2026 L.T.   
+
+# works with monetio: https://github.com/noaa-oar-arl/monetio - 0.3.2
+# works with (soon to be) melodies-monet v1.1: https://github.com/NCAR/MELODIES-MONET/tree/develop
+
+# works: https://github.com/L12D2/mm_uxarray/tree/backup/asia-aq-satellite-wip/docs/examples/ungridded_support/unstructured_grid_read_uxarray/tropomi_testing/works
+#-------------------------------------------------------------------
+analysis:
+  start_time: '2024-06-30'                 #UTC  
+  end_time:   '2024-06-30 23:59:00'        #UTC
+  output_dir:
+    ./output
+  output_dir_save:
+    ./output
+  output_dir_read:
+    ./output
+  save:
+    paired:
+      method: 'netcdf'
+      prefix: '20240101'
+      data: all
+  read:
+    paired:
+      method: 'netcdf'
+      filenames:
+        tempo_l2_no2_cam-chem-se: ['./output/20240101_tempo_l2_no2_cam-chem-se.nc4']
+  debug: false
+
+obs:
+  tempo_l2_no2:
+    debug: false
+    filename: /glade/campaign/acom/acom-da/sma/TEMPO_NO2_V03/TEMPO_NO2_L2_V03_20240630T*_S0*
+    obs_type: sat_swath_clm
+    sat_type: tempo_l2_no2
+    variables:
+      main_data_quality_flag:
+        main_data_quality_flag_max: 0
+        var_applied: ['vertical_column_troposphere']
+      vertical_column_troposphere:
+        ylabel_plot: 'NO2 trop. column'
+        vmin_plot: 0
+        vmax_plot: 1.0e+16
+      pressure: {}
+      tropopause_pressure: {}
+      scattering_weights: {}
+      amf_troposphere: {}
+
+model:
+  cam-chem-se:
+    files: 
+      - /glade/derecho/scratch/gaubert/tempo/f.e22.FCnudged.ne0CONUSne30x8_ne0CONUSne30x8_mt12.ref_dust_M1.001/f.e22.FCnudged.01x01.ref_dust_M1.001.cam.h1.2024-06-30-03600.nc
+    mod_type: 'cesm_fv'
+    mapping:
+      tempo_l2_no2:
+        NO2: "vertical_column_troposphere"
+    projection: ~
+    mod_kwargs:
+      convert_to_ppb: True
+      surf_only: false
+    plot_kwargs:
+      color: 'purple'
+      marker: '^'
+      linestyle: 'dotted'
+
+plots:
+  plot_grp1:
+    type: 'timeseries'
+    fig_kwargs: {figsize: [12, 6]}
+    default_plot_kwargs: {linewidth: 2.0, markersize: 10.}
+    text_kwargs: {fontsize: 18.}
+    domain_type: ["all"]
+    domain_name: ["CONUS"]
+    data: ["tempo_l2_no2_cam-chem-se"]
+    data_proc:
+      ts_offset: (-4, 'h')
+      ts_avg_window: 'h'
+      set_axis: true
+
+  plot_grp2:
+    type: 'gridded_spatial_bias'
+    fig_kwargs: {states: true, counties: false}
+    text_kwargs: {fontsize: 16}
+    domain_type: ['all', 'all']
+    domain_name: ['CONUS', 'model']
+    data: ['tempo_l2_no2_cam-chem-se']
+    data_proc: {set_axis: true}
+
+  plot_grp3:
+    type: 'spatial_dist'
+    fig_kwargs: {states: true, counties: false}
+    text_kwargs: {fontsize: 16}
+    domain_type: ['all', 'all']
+    domain_name: ['CONUS', 'model']
+    data: ['tempo_l2_no2_cam-chem-se']
+    data_proc: {set_axis: true, vmax: 1e16, vmin: 0}
+
+  plot_grp5:
+    type: 'taylor'
+    data: ['tempo_l2_no2_cam-chem-se']
+    domain_type: ['all']
+    domain_name: ['CONUS']
+    data_proc: {set_axis: true, ty_scale: 1.5}
+    default_plot_kwargs: {markersize: 10., marker: 's'}
+
+stats:
+  stat_list: ["MB", "MdnB", "R2", "RMSE"]
+  round_output: 2
+  output_table: False
+  domain_type: ["all"]
+  domain_name: ["CONUS"]
+  data: ['tempo_l2_no2_cam-chem-se']

--- a/examples/yaml/control_tropomi_l2_no2_cesm_se.yaml
+++ b/examples/yaml/control_tropomi_l2_no2_cesm_se.yaml
@@ -1,0 +1,134 @@
+
+#-------------------------------------------------------------------
+# MELODIES-MONET test: TROPOMI L2 NO2 vs CESM-FV 
+# updated 06/15/2026 L.T.
+
+# works with monetio: https://github.com/noaa-oar-arl/monetio - 0.3.2
+# works with (soon to be) melodies-monet v1.1: https://github.com/NCAR/MELODIES-MONET/tree/develop
+
+# works: https://github.com/L12D2/mm_uxarray/tree/backup/asia-aq-satellite-wip/docs/examples/ungridded_support/unstructured_grid_read_uxarray/tropomi_testing/works
+#-------------------------------------------------------------------
+analysis:
+  start_time: '2024-06-30'                 #UTC  
+  end_time:   '2024-06-30 23:59:00'        #UTC
+  output_dir: ./output_tropno2
+  output_dir_save: ./output_tropno2
+  output_dir_read: ./output_tropno2
+  debug: true
+
+  save:
+    paired: {method: 'netcdf', prefix: '20240601', data: all}
+  read:
+    paired:
+      method: 'netcdf'
+      filenames:
+        tropomi_l2_no2_cam-chem-se: ['./output_tropno2/20240101_tropomi_l2_no2_cam-chem-se.nc4']
+        
+  pairing_kwargs:
+    sat_swath_clm:
+      apply_ak: True
+      mod_to_overpass: True
+  
+obs:
+  tropomi_l2_no2:
+    regrid_method: nearest_s2d
+    debug: false
+    filename: /glade/campaign/acom/acom-weather/amirrezaei/tropomi_no2/2024/S5P_OFFL_L2__NO2____20240630T*.nc
+    obs_type: sat_swath_clm
+    sat_type: tropomi_l2_no2
+    sat_method: replace_apriori
+    apply_ak: True
+    variables:
+        qa_value:
+            quality_flag_min: 0.75
+            var_applied: ['nitrogendioxide_tropospheric_column']
+            fillvalue: 9.96921e+36
+        nitrogendioxide_tropospheric_column:
+            scale: 6.022141e+19          # mol/m2 -> molec/cm2
+            fillvalue: 9.96921e+36
+            ylabel_plot: 'NO2 trop. columns'
+            vmin_plot: 0.0
+            vmax_plot: 1.0e+16
+            nlevels_plot: 23
+            regulatory: False
+        averaging_kernel:
+            fillvalue: 9.96921e+36
+        air_mass_factor_total:
+            fillvalue: 9.96921e+36
+        air_mass_factor_troposphere:
+            fillvalue: 9.96921e+36
+        latitude: None
+        longitude: None
+        preslev:                         # pressure of the vertical layer centers
+            tm5_constant_a:
+                group: ['PRODUCT']
+                maximum: 9.0e+36
+            tm5_constant_b:
+                group: ['PRODUCT']
+                maximum: 9.0e+36
+            surface_pressure:
+                group: ['PRODUCT/SUPPORT_DATA/INPUT_DATA/']
+                maximum: 9.0e+36
+            tm5_tropopause_layer_index:
+                group: ['PRODUCT']
+
+          
+model:
+  cam-chem-se:
+    files: 
+      - /glade/derecho/scratch/gaubert/tempo/f.e22.FCnudged.ne0CONUSne30x8_ne0CONUSne30x8_mt12.ref_dust_M1.001/f.e22.FCnudged.01x01.ref_dust_M1.001.cam.h1.2024-06-30-03600.nc
+    mod_type: 'cesm_fv'
+    mod_to_overpass: True
+    mapping:
+      tropomi_l2_no2:
+        NO2: "nitrogendioxide_tropospheric_column"
+    projection: ~
+    mod_kwargs:
+      convert_to_ppb: True
+      surf_only: false
+    plot_kwargs: {color: 'purple', marker: '^', linestyle: 'dotted'}
+
+plots:
+  plot_grp1:
+    type: 'spatial_dist'
+    fig_kwargs: {states: true, counties: false, extent: [-127, -65, 23, 50], cmap: 'Spectral_r'}
+    text_kwargs: {fontsize: 16}
+    domain_type: ['all', 'all']
+    domain_name: ['CONUS', 'model']
+    data: ['tropomi_l2_no2_cam-chem-se']
+    data_proc: {set_axis: false, vmin_plot: 0, vmax_plot: 6.0e+15}
+
+  plot_grp2:
+    type: 'gridded_spatial_bias'
+    fig_kwargs: {states: true, counties: false, cmap: 'RdBu_r'}
+    text_kwargs: {fontsize: 16}
+    domain_type: ['all', 'all']
+    domain_name: ['CONUS', 'model']
+    data: ['tropomi_l2_no2_cam-chem-se']
+    data_proc: {set_axis: false, vdiff_plot: 2.0e+15}
+
+  plot_grp3:
+    type: 'timeseries'
+    fig_kwargs: {figsize: [12, 6]}
+    default_plot_kwargs: {linewidth: 2.0, markersize: 10.}
+    text_kwargs: {fontsize: 18.}
+    domain_type: ["all"]
+    domain_name: ["CONUS"]
+    data: ["tropomi_l2_no2_cam-chem-se"]
+    data_proc: {set_axis: false, vmin_plot: 0, vmax_plot: 6.0e+15}
+
+  plot_grp5:
+    type: 'taylor'
+    data: ["tropomi_l2_no2_cam-chem-se"]
+    domain_type: ['all']
+    domain_name: ['CONUS']
+    data_proc: {set_axis: true, ty_scale: 1.5}
+    default_plot_kwargs: {markersize: 10., marker: 's'}
+    
+stats:
+  stat_list: ["MB", "MdnB", "R2", "RMSE"]
+  round_output: 2
+  output_table: False
+  domain_type: ["all"]
+  domain_name: ["CONUS"]
+  data: ['tropomi_l2_no2_cam-chem-se']

--- a/melodies_monet/driver/_analysis.py
+++ b/melodies_monet/driver/_analysis.py
@@ -873,7 +873,7 @@ class analysis:
                             print('Pairing is being done for model variable: '+keys[i_no2_varname[0]])
                         no2_varname = keys[i_no2_varname[0]]
 
-                        if m.mod_to_overpass:
+                        if mod.mod_to_overpass:
                             print("sampling model to 13:30 local overpass time")
                             overpass_datetime = pd.date_range(
                                 self.start_time.replace(hour=13, minute=30),
@@ -1042,7 +1042,7 @@ class analysis:
                             model_obj = mod.obj[keys + ["pres_pa_mid"]]
 
                             # Sample model to observation overpass time
-                            if m.mod_to_overpass:
+                            if mod.mod_to_overpass:
                                 print("sampling model to 10:30 local overpass time")
                                 overpass_datetime = pd.date_range(
                                     self.start_time.replace(hour=10, minute=30),

--- a/melodies_monet/driver/_model.py
+++ b/melodies_monet/driver/_model.py
@@ -238,12 +238,7 @@ class model:
                 self.obj = mio.fv3chem.open_dataset(self.files, **self.mod_kwargs)
         elif "cesm_fv" in self.model.lower():
             print("**** Reading CESM FV model output...")
-            self.mod_kwargs.update(
-                {
-                    "var_list": list_input_var,
-                    "surf_only": control_dict["model"][self.label].get("surf_only", False),
-                }
-            )
+            self.mod_kwargs.update({"var_list": list_input_var})
             try:
                 self.obj = mio.models.cesm_fv.open_mfdataset(self.files, **self.mod_kwargs)
             except AttributeError:
@@ -251,12 +246,7 @@ class model:
         # CAM-chem-SE grid or MUSICAv0
         elif "cesm_se" in self.model.lower():
             print("**** Reading CESM SE model output...")
-            self.mod_kwargs.update(
-                {
-                    "var_list": list_input_var,
-                    "surf_only": control_dict["model"][self.label].get("surf_only", False),
-                }
-            )
+            self.mod_kwargs.update({"var_list": list_input_var})
             if self.scrip_file.startswith("example:"):
                 from melodies_monet import tutorial
 

--- a/melodies_monet/driver/_model.py
+++ b/melodies_monet/driver/_model.py
@@ -238,7 +238,12 @@ class model:
                 self.obj = mio.fv3chem.open_dataset(self.files, **self.mod_kwargs)
         elif "cesm_fv" in self.model.lower():
             print("**** Reading CESM FV model output...")
-            self.mod_kwargs.update({"var_list": list_input_var})
+            self.mod_kwargs.update(
+                {
+                    "var_list": list_input_var,
+                    "surf_only": control_dict["model"][self.label].get("surf_only", False),
+                }
+            )
             try:
                 self.obj = mio.models.cesm_fv.open_mfdataset(self.files, **self.mod_kwargs)
             except AttributeError:
@@ -246,7 +251,12 @@ class model:
         # CAM-chem-SE grid or MUSICAv0
         elif "cesm_se" in self.model.lower():
             print("**** Reading CESM SE model output...")
-            self.mod_kwargs.update({"var_list": list_input_var})
+            self.mod_kwargs.update(
+                {
+                    "var_list": list_input_var,
+                    "surf_only": control_dict["model"][self.label].get("surf_only", False),
+                }
+            )
             if self.scrip_file.startswith("example:"):
                 from melodies_monet import tutorial
 


### PR DESCRIPTION
- _model.py: forward surf_only into the cesm_fv reader. It was defaulting to surf_only=True, so pres_pa_mid/dz_m/temperature_k were never built, breaking satellite/AK pairing with KeyError: 'pres_pa_mid' / 'dz_m'.
- _analysis.py: in pair_data, read mod_to_overpass off the model object (mod) instead of the shadowed 'import monet as m' module, which raised AttributeError: module 'monet' has no attribute 'mod_to_overpass'.

Once these changes are in for v1.1, cesm-fv can do TEMPO NO2, HCHO and Tropomi NO2

The "working" yaml files with monetio 0.3.2 and these changes are in: https://github.com/L12D2/mm_uxarray/tree/backup/asia-aq-satellite-wip/docs/examples/ungridded_support/unstructured_grid_read_uxarray/tropomi_testing/works  