### PR TITLE
Upper-bound typer (`<0.26`) for docs

### DIFF
--- a/docs/develop/developers_guide.rst
+++ b/docs/develop/developers_guide.rst
@@ -97,7 +97,7 @@ branch of one, you should use the develop branch of all of them for consistency.
        $ conda install -y -c conda-forge pyyaml pandas=2 monet monetio \
          "netcdf4<1.7" "setuptools<70" "dask>=2024.2.1" wrf-python \
          "cartopy=0.24" metpy windrose statannotations \
-         "typer<0.26" rich pooch jupyterlab
+         typer rich pooch jupyterlab
 
 (b) Now, install the **develop** branch of **MELODIES MONET** to the environment::
 
@@ -135,7 +135,7 @@ changes on your fork, and submit a pull request with your changes to the develop
        $ conda install -y -c conda-forge pyyaml pandas=2 monet monetio \
          "netcdf4<1.7" "setuptools<70" "dask>=2024.2.1" wrf-python \
          "cartopy=0.24" metpy windrose statannotations \
-         "typer<0.26" rich pooch jupyterlab
+         typer rich pooch jupyterlab
 
 (b) Fork the GitHub repositories to your own GitHub account
     using the "Fork" button near the top right for the following repositories:

--- a/docs/develop/developers_guide.rst
+++ b/docs/develop/developers_guide.rst
@@ -97,7 +97,7 @@ branch of one, you should use the develop branch of all of them for consistency.
        $ conda install -y -c conda-forge pyyaml pandas=2 monet monetio \
          "netcdf4<1.7" "setuptools<70" "dask>=2024.2.1" wrf-python \
          "cartopy=0.24" metpy windrose statannotations \
-         typer rich pooch jupyterlab
+         "typer<0.26" rich pooch jupyterlab
 
 (b) Now, install the **develop** branch of **MELODIES MONET** to the environment::
 
@@ -135,7 +135,7 @@ changes on your fork, and submit a pull request with your changes to the develop
        $ conda install -y -c conda-forge pyyaml pandas=2 monet monetio \
          "netcdf4<1.7" "setuptools<70" "dask>=2024.2.1" wrf-python \
          "cartopy=0.24" metpy windrose statannotations \
-         typer rich pooch jupyterlab
+         "typer<0.26" rich pooch jupyterlab
 
 (b) Fork the GitHub repositories to your own GitHub account
     using the "Fork" button near the top right for the following repositories:
@@ -199,7 +199,7 @@ from the MELODIES MONET repository,
 or add the following packages to your conda environment manually::
 
     $ conda install -y -c conda-forge sphinx=7.* sphinx_rtd_theme myst-nb>=0.14 sphinx-design \ 
-      sphinx-click sphinx-togglebutton typer
+      sphinx-click sphinx-togglebutton "typer<0.26"
 
 The restructured text sources (rst) are located
 in the ``MELODIES-MONET/docs`` folders.

--- a/docs/develop/developers_guide.rst
+++ b/docs/develop/developers_guide.rst
@@ -97,7 +97,7 @@ branch of one, you should use the develop branch of all of them for consistency.
        $ conda install -y -c conda-forge pyyaml pandas=2 monet monetio \
          "netcdf4<1.7" "setuptools<70" "dask>=2024.2.1" wrf-python \
          "cartopy=0.24" metpy windrose statannotations \
-         typer rich pooch jupyterlab
+         typer pooch jupyterlab
 
 (b) Now, install the **develop** branch of **MELODIES MONET** to the environment::
 
@@ -135,7 +135,7 @@ changes on your fork, and submit a pull request with your changes to the develop
        $ conda install -y -c conda-forge pyyaml pandas=2 monet monetio \
          "netcdf4<1.7" "setuptools<70" "dask>=2024.2.1" wrf-python \
          "cartopy=0.24" metpy windrose statannotations \
-         typer rich pooch jupyterlab
+         typer pooch jupyterlab
 
 (b) Fork the GitHub repositories to your own GitHub account
     using the "Fork" button near the top right for the following repositories:

--- a/docs/environment-docs.yml
+++ b/docs/environment-docs.yml
@@ -19,7 +19,7 @@ dependencies:
   - numba
   - pooch
   - timezonefinder
-  - typer
+  - typer<0.26
   - wrf-python  # for WRF-Chem reader in monetio
   #
   # Docs

--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -77,7 +77,7 @@ Add dependencies from conda-forge::
     $ conda install -y -c conda-forge pyyaml pandas=2 monet monetio \
       "netcdf4<1.7" "setuptools<70" "dask>=2024.2.1" wrf-python \
       "cartopy=0.24" metpy windrose statannotations \
-      typer rich pooch jupyterlab
+      "typer<0.26" rich pooch jupyterlab
    
 Now, install the stable branch of MELODIES MONET to the environment::
 

--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -77,7 +77,7 @@ Add dependencies from conda-forge::
     $ conda install -y -c conda-forge pyyaml pandas=2 monet monetio \
       "netcdf4<1.7" "setuptools<70" "dask>=2024.2.1" wrf-python \
       "cartopy=0.24" metpy windrose statannotations \
-      "typer<0.26" rich pooch jupyterlab
+      typer rich pooch jupyterlab
    
 Now, install the stable branch of MELODIES MONET to the environment::
 

--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -15,8 +15,7 @@ Optional dependencies
 
 - ``netcdf4`` (`from Unidata <https://unidata.github.io/netcdf4-python/>`__; most likely needed for reading model/obs datasets)
 - ``wrf-python`` (needed in order to use the WRF-Chem reader; note that the version of ``wrf-python`` compatible with python=3.11 has known incompatibilities with newer ``netCDF4`` and ``setuptools`` versions — see *Incompatibilities* below)
-- ``typer`` (to use the :doc:`/cli`;
-  add ``rich`` `for <https://typer.tiangolo.com/release-notes/#060-2022-07-12>`__ fancy tracebacks and ``--help``)
+- ``typer`` (to use the :doc:`/cli`)
 - ``pooch`` (to enable automatic downloading of :doc:`tutorial datasets </examples/tutorial-data>`)
 - ``regionmask`` (`for complex region masking support <https://regionmask.readthedocs.io/en/stable/>`__; can read shapefiles, geojson, arbitrary polygons and predefined regions.)
 - ``metpy`` (for meteorological calculations)
@@ -77,7 +76,7 @@ Add dependencies from conda-forge::
     $ conda install -y -c conda-forge pyyaml pandas=2 monet monetio \
       "netcdf4<1.7" "setuptools<70" "dask>=2024.2.1" wrf-python \
       "cartopy=0.24" metpy windrose statannotations \
-      typer rich pooch jupyterlab
+      typer pooch jupyterlab
    
 Now, install the stable branch of MELODIES MONET to the environment::
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ install_requires =
 tutorial =
   pooch
 cli =
-  typer[all]
+  typer <0.26
 all =
   %(tutorial)s
   %(cli)s

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ install_requires =
 tutorial =
   pooch
 cli =
-  typer <0.26
+  typer
 all =
   %(tutorial)s
   %(cli)s


### PR DESCRIPTION
to before Click was vendored

working again: https://melodies-monet--447.org.readthedocs.build/en/447/cli.html

cc: @rschwant 