### PR TITLE
B3b tempo conservative

### DIFF
--- a/melodies_monet/driver/_model.py
+++ b/melodies_monet/driver/_model.py
@@ -5,6 +5,11 @@ import warnings
 import xarray as xr
 import monetio as mio
 
+try:
+    import uxarray as ux
+except ImportError:  # optional dep
+    ux = None
+
 
 class model:
     """The model class.
@@ -16,6 +21,7 @@ class model:
         """Initialize a :class:`model` object."""
         self.model = None
         self.is_global = False
+        self.is_track = False
         self.radius_of_influence = None
         self.mod_kwargs = {}
         self.file_str = None
@@ -35,6 +41,10 @@ class model:
         self.plot_kwargs = None
         self.proj = None
         self.mod_to_overpass = False
+
+        # Build in uxarray native support ; populate for the scrip file provided in cesm-se 
+        self.uxds = None
+        self.uxgrid = None
 
     def __repr__(self):
         return (
@@ -243,22 +253,82 @@ class model:
                 self.obj = mio.models.cesm_fv.open_mfdataset(self.files, **self.mod_kwargs)
             except AttributeError:
                 self.obj = mio.models._cesm_fv_mm.open_mfdataset(self.files, **self.mod_kwargs)
+       
         # CAM-chem-SE grid or MUSICAv0
-        elif "cesm_se" in self.model.lower():
-            print("**** Reading CESM SE model output...")
+        elif "cesm_se" in self.model.lower() or "mpas" in self.model.lower():
+            print("**** Reading CAM unstructured model output (cesm_se / mpas)...")
             self.mod_kwargs.update({"var_list": list_input_var})
-            if self.scrip_file.startswith("example:"):
-                from melodies_monet import tutorial
 
-                example_id = ":".join(s.strip() for s in self.scrip_file.split(":")[1:])
-                self.scrip_file = tutorial.fetch_example(example_id)
-            self.mod_kwargs.update({"scrip_file": self.scrip_file})
+            # Grid geometry: SCRIP (CESM-SE) or native MPAS mesh/init file.
+            scrip = getattr(self, "scrip_file", None)
+            mesh = getattr(self, "mesh_file", None)
+            if scrip and scrip.startswith("example:"):
+                from melodies_monet import tutorial
+                example_id = ":".join(s.strip() for s in scrip.split(":")[1:])
+                scrip = self.scrip_file = tutorial.fetch_example(example_id)
+            ux_grid_path = scrip or mesh
+            if ux_grid_path is None:
+                raise ValueError(
+                    'CAM unstructured output (cesm_se / mpas) requires '
+                    '"scrip_file" (SCRIP, e.g. CESM-SE) or "mesh_file" '
+                    '(MPAS mesh/init file) in the YAML config.')
+
+            if scrip:
+                self.mod_kwargs.update({"scrip_file": scrip})
+            if mesh:
+                self.mod_kwargs.update({"mesh_file": mesh})
+            print(f"Using unstructured grid file: {ux_grid_path}")
+
+            # monetio's unstructured CAM reader is _cam_unstructured in recent
+            # versions (it also handles the MPAS mesh_file input); fall back to
+            # the older cesm_se module names so released monetio still works.
             try:
-                self.obj = mio.models.cesm_se.open_mfdataset(self.files, **self.mod_kwargs)
-            except AttributeError:
-                self.obj = mio.models._cesm_se_mm.open_mfdataset(self.files, **self.mod_kwargs)
-            # self.obj, self.obj_scrip = read_cesm_se.open_mfdataset(self.files,**self.mod_kwargs)
-            # self.obj.monet.scrip = self.obj_scrip
+                from monetio.models import _cam_unstructured
+            except ImportError:
+                if mesh:
+                    raise ImportError(
+                        'MPAS "mesh_file" input requires the monetio '
+                        'unstructured CAM reader '
+                        '(monetio.models._cam_unstructured), which this monetio '
+                        'version does not provide. Please update monetio.'
+                    )
+                try:
+                    self.obj = mio.models.cesm_se.open_mfdataset(
+                        self.files, **self.mod_kwargs)
+                except AttributeError:
+                    self.obj = mio.models._cesm_se_mm.open_mfdataset(
+                        self.files, **self.mod_kwargs)
+            else:
+                self.obj = _cam_unstructured.open_mfdataset(
+                    self.files, **self.mod_kwargs)
+            
+            try:
+                self.uxgrid = ux.open_grid(ux_grid_path)
+                print("**** Opened uxarray grid:", ux_grid_path)
+            except Exception as e:
+                self.uxgrid = None
+                warnings.warn(f"Could not open uxarray grid from {ux_grid_path!r}; "
+                    f"continuing with the legacy plotting path. Reason: {e}")
+            if scrip:
+                self.obj.attrs['mio_scrip_file'] = scrip
+            if mesh:
+                self.obj.attrs['mio_mesh_file'] = mesh
+                
+            self.obj.attrs['mio_has_unstructured_grid'] = True
+
+            # insert this here for the unstructured grid stuff. This renaming may be breakng somewhere else, but gets it out of the 
+            # juypter notebook. 
+            _rename = {}
+            if "lon" in self.obj.data_vars and "longitude" not in self.obj.variables:
+                _rename["lon"] = "longitude"
+            if "lat" in self.obj.data_vars and "latitude" not in self.obj.variables:
+                _rename["lat"] = "latitude"
+            if _rename:
+                self.obj = self.obj.rename(_rename)
+            _promote = [c for c in ("longitude", "latitude") if c in self.obj.data_vars]
+            if _promote:
+                self.obj = self.obj.set_coords(_promote)
+
         elif "camx" in self.model.lower():
             self.mod_kwargs.update({"var_list": list_input_var})
             self.mod_kwargs.update(
@@ -276,6 +346,7 @@ class model:
                 #the _camx_mm.py reader and not the camx.py reader, which is old.
             except AttributeError:
                 self.obj = mio.models.camx.open_mfdataset(self.files, **self.mod_kwargs)
+                
         elif "raqms" in self.model.lower():
             self.mod_kwargs.update({"var_list": list_input_var})
             if time_interval is not None:

--- a/melodies_monet/plots/uxarray_render.py
+++ b/melodies_monet/plots/uxarray_render.py
@@ -1,0 +1,148 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Shared uxarray rendering for unstructured model fields.
+
+A single entry point, :func:`render_unstructured_field`, that every spatial
+plot type (overlay, spatial_dist, gridded bias, satellite overlay, ...) can
+call to draw a 1-D unstructured column field as filled grid-cell polygons on a
+cartopy axis. This is the uxarray-native replacement for the legacy
+``Plot_2D`` SE path.
+
+Color scaling is controlled by the caller via ``norm``/``cmap`` (so linear,
+log via ``SymLogNorm``, or diff via a diverging norm/cmap all work without
+special-casing here). Data binding/alignment lives in
+:mod:`melodies_monet.util.uxarray_util`.
+
+take 1D unstructured fields; a uxarray mesh (grid file); plotting metadata to plot:
+
+- polygon collection that represents the mesh cells 
+- render directly on cartopy map axis 
+
+"""
+
+# https://uxarray.readthedocs.io/en/latest/user-guide/grid-formats.html 
+
+import cartopy.crs as ccrs
+import cartopy.feature as cfeature
+
+from melodies_monet.util.uxarray_util import uxda_from_columns
+
+def render_unstructured_field(
+    ax,
+    field,
+    uxgrid,
+    *,
+    cmap,
+    norm=None,
+    vmin=None,
+    vmax=None,
+    extent=None,
+    coast=True,
+    borders=True,
+    states=True,
+    gridlines=True,
+    colorbar=True,
+    cbar_label=None,
+    cbar_kwargs=None,
+    text_kwargs=None,
+    periodic_elements="split",):
+    
+    """Draw a 1-D unstructured column ``field`` as polygons on a cartopy ``ax``.
+
+    Parameters
+    ----------
+    ax : cartopy GeoAxes
+        Axis (already created with a projection) to draw on.
+    field : xarray.DataArray
+        1-D model field over the unstructured column dimension, with 1-D
+        ``longitude``/``latitude`` coordinates (e.g. a time-mean slice).
+    uxgrid : uxarray.Grid
+        Grid the field is bound to (model.uxgrid).
+    cmap : matplotlib colormap
+    norm : matplotlib.colors.Normalize, optional
+        If given, controls color scaling (use ``SymLogNorm`` for log,
+        ``TwoSlopeNorm``/``BoundaryNorm`` for diff). Takes precedence over
+        ``vmin``/``vmax``.
+    vmin, vmax : float, optional
+        Used only when ``norm`` is None.
+    extent : [lonmin, lonmax, latmin, latmax], optional
+        Map extent in PlateCarree degrees.
+    coast, borders, states, gridlines, colorbar : bool
+        Toggle cartopy features / decorations.
+    cbar_label : str, optional
+    cbar_kwargs : dict, optional
+        Overrides for ``figure.colorbar`` (default shrink/pad/extend).
+    text_kwargs : dict, optional
+        Passed to the colorbar label text.
+    periodic_elements : {"split", "exclude", "ignore"}
+        Antimeridian (±180°) handling for cells that straddle the seam.
+        - "split" (default): split wrapping cells into correct polygons.
+          Required for GLOBAL meshes (e.g. MPAS, ne0CONUS) -- otherwise
+          wrapped cells smear as full-width horizontal bands across the plot.
+        - "exclude": drop wrapping cells (a thin gap at ±180° only; faster).
+        - "ignore": draw as-is -- ONLY safe for a purely regional mesh that
+          never crosses ±180°. Produces horizontal-stripe artifacts on any
+          mesh with antimeridian-crossing cells.
+
+    Returns
+    -------
+    matplotlib.collections.PolyCollection
+        The polygon collection added to ``ax`` (e.g. to attach a colorbar to).
+    """
+    
+    uxda = uxda_from_columns(field, uxgrid)
+
+    # need to subset mesh before building polygons. "set_extent" crops the view but still builds every polygon. 
+    if extent is not None:
+        try:
+            lonmin, lonmax, latmin, latmax = (float(v) for v in extent)
+            pad = 1.0 # degrees; cells straddling the edge aren't clipped
+            lon_b = (lonmin - pad, lonmax + pad)
+            lat_b = (latmin - pad, latmax + pad)
+            try:
+                uxda = uxda.subset.bounding_box(lon_b, lat_b, element="face centers")
+            except TypeError:
+                uxda = uxda.subset.bounding_box(lon_b, lat_b)
+        except Exception as e:  # noqa: BLE001
+            print(
+                f"render_unstructured_field: extent subset skipped ({e}); "
+                "rendering full mesh."
+            )
+
+    poly = uxda.to_polycollection(periodic_elements=periodic_elements)
+    # older uxarray returned (poly, corrected_to_gdf); newer returns poly only
+    if isinstance(poly, tuple):
+        poly = poly[0]
+
+    poly.set_cmap(cmap)
+    if norm is not None:
+        poly.set_norm(norm)
+    else:
+        poly.set_clim(vmin=vmin, vmax=vmax)
+    poly.set_edgecolor("face")
+    poly.set_transform(ccrs.PlateCarree())
+    ax.add_collection(poly)
+
+    if coast:
+        ax.coastlines(lw=0.5)
+    if borders:
+        ax.add_feature(cfeature.BORDERS, lw=0.5)
+    if states:
+        ax.add_feature(cfeature.STATES, lw=0.3)
+    if extent is not None:
+        ax.set_extent(extent, crs=ccrs.PlateCarree())
+
+    if gridlines:
+        gl = ax.gridlines(draw_labels=True, lw=1.0, color="black", alpha=0.5, linestyle=":")
+        gl.top_labels = False
+        gl.right_labels = False
+
+    if colorbar:
+        cbk = dict(shrink=0.8, pad=0.04, extend="both")
+        if cbar_kwargs:
+            cbk.update(cbar_kwargs)
+        cbar = ax.figure.colorbar(poly, ax=ax, **cbk)
+        if cbar_label is not None:
+            cbar.set_label(cbar_label, fontweight="bold", **(text_kwargs or {}))
+
+    return poly

--- a/melodies_monet/util/regrid_util.py
+++ b/melodies_monet/util/regrid_util.py
@@ -2,10 +2,186 @@
 #
 """
 file: regrid_util.py
-"""
-import os
-import xarray as xr
 
+MM regridding utilities 
+
+1. **Config-driven xESMF regridder** (:func:`setup_regridder`,
+   :func:`filename_regrid`): builds xESMF regridders from the analysis
+   YAML's ``regrid`` blocks. Used by the structured obs/model regridding
+   path in the driver.
+   
+2. **Model-agnostic regridder** (:func:`regrid`): a single entry point
+   that dispatches on method to one of two backends:
+
+   - **ckdtree** (``nearest_s2d`` / ``nearest_d2s`` / ``radius_mean``):
+     point sampling of an unstructured source at arbitrary target points
+     via a cached :class:`scipy.spatial.cKDTree`. Fast; does NOT conserve
+     mass. 
+     
+   - **xregrid** (``conservative`` / ``bilinear`` / ``patch``): true
+     area-weighted (or interpolated) regridding via ESMF. Conservative
+     conserves mass. Unstructured sources (e.g. ne0CONUS) are read from a
+     SCRIP mesh whose padded/degenerate corners are depadded into a clean
+     UGRID first (see
+     :func:`melodies_monet.util.uxarray_util.clean_uxgrid_from_scrip`).
+
+Usage of :func:`regrid`
+-----------------------
+Nearest-neighbor sample of an unstructured model at swath pixels:
+
+>>> from melodies_monet.util.regrid_util import regrid
+>>> out = regrid(
+...     modobj,
+...     target={"lon": obs["lon"].values, "lat": obs["lat"].values},
+...     method="nearest_s2d",
+...     target_dims=("x", "y"),
+... )
+
+Conservative (mass-preserving) regrid of an unstructured model to a
+rectilinear grid:
+
+>>> out = regrid(
+...     modobj,
+...     target={"lon": np.arange(-130, -60, 0.1), "lat": np.arange(20, 55, 0.1)},
+...     method="conservative",
+...     src_grid="/path/to/ne0CONUS_ne30x8_np4_SCRIP.nc",
+... )
+
+"""
+
+import os
+import gc
+import xarray as xr
+import numpy as np
+try:
+    import uxarray as ux
+except ImportError:  # optional dep
+    ux = None
+try:
+    from xregrid import Regridder
+except ImportError:  # optional dep
+    Regridder = None
+
+_LON_NAMES = ("longitude", "lon", "Longitude")
+_LAT_NAMES = ("latitude", "lat", "Latitude")
+
+_CKDTREE_METHODS = ("nearest_s2d", "nearest_d2s", "radius_mean")
+_XREGRID_METHODS = ("conservative", "conservative_normed", "bilinear", "patch")
+
+# One-shot notice flag for the xregrid weight-row-sum workaround.
+_COVERAGE_NOTICE_SHOWN = False
+
+# Optional Dask-parallel xregrid weight generation (env-gated, default OFF so
+# existing runs are unchanged).
+_XREGRID_PARALLEL = os.environ.get("MM_XREGRID_PARALLEL", "").strip().lower() in (
+    "1", "on", "true", "yes")
+_XREGRID_CLIENT = None
+
+def _patch_ux_isel_slices():
+    """Teach UxDataset.isel to accept slice indexers (idempotent).
+
+    xregrid's parallel weight generation chunks the source grid with
+    ``ds.isel(n_face=slice(a, b))``; uxarray's Grid.isel only takes explicit
+    index arrays (``_slice_face_indices`` does ``np.asarray(indices, int)`` ->
+    "TypeError: int() argument ... not 'slice'"). Expand any slice indexer to
+    ``np.arange`` before delegating to the original isel.
+    """
+    if getattr(ux.UxDataset.isel, "_mm_slice_ok", False):
+        return
+    _orig_isel = ux.UxDataset.isel
+
+    def _isel_slices_ok(self, indexers=None, **kwargs):
+        merged = dict(indexers or {}); merged.update(kwargs)
+        for dim, idx in list(merged.items()):
+            if isinstance(idx, slice) and dim in self.sizes:
+                merged[dim] = np.arange(*idx.indices(self.sizes[dim]))
+        return _orig_isel(self, **merged)
+
+    _isel_slices_ok._mm_slice_ok = True
+    ux.UxDataset.isel = _isel_slices_ok
+    
+def _ensure_xregrid_client():
+    """Lazily create (once per process) a right-sized dask.distributed client for
+    xregrid's parallel weight generation. No-op / None if parallel is off or dask
+    is unavailable (xregrid then just runs serial)."""
+    global _XREGRID_CLIENT
+    if not _XREGRID_PARALLEL:
+        return None
+    _patch_ux_isel_slices()          # main process (xregrid chunks source here)
+    if _XREGRID_CLIENT is not None:
+        return _XREGRID_CLIENT
+    try:
+        import dask.distributed as dd
+    except ImportError:
+        print("regrid: MM_XREGRID_PARALLEL set but dask.distributed is missing; "
+              "running serial.", flush=True)
+        return None
+    try:
+        _XREGRID_CLIENT = dd.get_client()                 # reuse existing client
+    except ValueError:
+        n = int(os.environ.get("MM_XREGRID_WORKERS",
+                os.environ.get("PBS_NCPUS", os.environ.get("NCPUS", "4"))))
+        cluster = dd.LocalCluster(n_workers=n, threads_per_worker=1, processes=True)
+        _XREGRID_CLIENT = dd.Client(cluster)
+        print(f"regrid: dask LocalCluster with {n} workers for xregrid parallel "
+              "weight generation.", flush=True)
+    try:
+        # workers may also isel shipped UxDatasets -- patch them too
+        _XREGRID_CLIENT.run(_patch_ux_isel_slices)
+    except Exception:
+        pass
+    return _XREGRID_CLIENT
+
+def _release_esmf(rg):
+    """Best-effort release of ESMF-side memory held by an xregrid Regridder.
+
+    ESMF (esmpy) allocates meshes/routehandles in a Fortran heap that Python's
+    GC does NOT reclaim when the Regridder goes out of scope. In the TEMPO
+    pairing loop a new Regridder is built per granule per direction (forward
+    and backward), each constructing ESMF meshes for the 174k-face model and
+    ~270k-cell swath -- so without explicit destruction the process leaks
+    hundreds of MB per granule (observed: 150+ GB over a multi-day run).
+
+    We try every destroy hook xregrid/esmpy might expose, drop the heavy
+    attributes (sparse weight matrices), then force a GC pass.
+    """
+    if rg is None:
+        return
+
+    def _safe_get(obj, name):
+        try:
+            return getattr(obj, name, None)
+        except Exception:
+            return None
+
+    # Destroy ESMF objects the Regridder may hold (names vary across versions).
+    objs = [rg, _safe_get(rg, "regrid"), _safe_get(rg, "_regrid"),
+            _safe_get(rg, "esmf_regrid")]
+    for obj in objs:
+        if obj is None:
+            continue
+        for attr in ("destroy", "_destroy", "free", "release"):
+            fn = _safe_get(obj, attr)
+            if callable(fn):
+                try:
+                    fn()
+                except Exception:
+                    pass
+    # Drop heavy cached arrays by clearing the INSTANCE dict directly
+    inst = getattr(rg, "__dict__", {})
+    for attr in ("_weights_matrix", "_total_weights", "_regrid", "regrid",
+                 "esmf_regrid"):
+        if attr in inst:
+            try:
+                inst[attr] = None
+            except Exception:
+                pass
+    del rg
+    gc.collect()
+
+# ==========================================================================
+# Config-driven xESMF regridder (structured obs/model path)
+# ==========================================================================
 
 def setup_regridder(config, config_group='obs', target_grid=None):
     """
@@ -59,3 +235,379 @@ def filename_regrid(filename, regridder):
 
     return filename_regrid
 
+# ==========================================================================
+# Model-agnostic regridder (dispatches to ckdtree or xregrid)
+# ==========================================================================
+
+def regrid(
+    src,
+    target = None,
+    method="nearest_s2d",
+    src_lon=None,
+    src_lat=None,
+    src_grid=None,
+    target_grid=None,
+    target_dims=None,
+    max_distance=None,
+    radius=None,
+    backend="auto",
+):
+    """Model-agnostic regrid dispatcher.
+
+    - **ckdtree** (``nearest_s2d`` / ``nearest_d2s`` / ``radius_mean``):
+      point sampling. ``target`` is scattered points; no cell geometry
+      needed. Does NOT conserve mass.
+      
+    - **xregrid** (``conservative`` / ``bilinear`` / ``patch``): true
+      area-weighted (or interpolated) regridding via ESMF. Requires the
+      source's mesh (``src_grid``) and a target that defines cells. The
+      conservative method **conserves mass**.
+
+    Parameters
+    ----------
+    src : xr.Dataset or ux.UxDataset
+        Source data. For ckdtree: must carry 1-D longitude/latitude coords
+        on its column dim. For xregrid: either a UxDataset, or a plain
+        Dataset whose column dim length matches the ``src_grid`` mesh.
+    target : dict
+        Target spec, ``{"lon": ..., "lat": ...}``.
+
+        - ckdtree: lon/lat are point arrays of identical shape.
+        - xregrid: lon/lat are **1-D** coordinate axes of a rectilinear
+          grid (lengths may differ). Cell bounds are inferred by xregrid.
+    method : str, default "nearest_s2d"
+        See backend list above.
+    src_lon, src_lat : str, optional
+        Names of source longitude/latitude coords (ckdtree only).
+        Auto-detected if not given.
+    src_grid : str or uxarray.Grid, optional
+        Source mesh for unstructured xregrid sources: a SCRIP path (depadded
+        into a clean UGRID via
+        :func:`melodies_monet.util.uxarray_util.clean_uxgrid_from_scrip`) or a
+        pre-built ``uxarray.Grid``. Required for conservative/bilinear unless
+        ``src`` is already a UxDataset.
+    target_grid : uxarray.Grid, optional
+        Unstructured **target** mesh (xregrid only). Use this for a curvilinear
+        target like a TEMPO swath: build a ``uxarray.Grid`` from the pixel
+        corner bounds (see
+        :func:`melodies_monet.util.uxarray_util.uxgrid_from_corner_bounds`)
+        and pass it here. Output lands on that grid's ``n_face`` dim. When
+        given, ``target`` is ignored.
+    target_dims : tuple of str, optional
+        Output spatial dim names (ckdtree only).
+    max_distance : float, optional
+        Nearest-neighbor distance cap, degrees (ckdtree nearest only).
+    radius : float, optional
+        Averaging radius, degrees (ckdtree ``radius_mean`` only).
+    backend : str, default "auto"
+        ``"auto"`` picks ckdtree for nearest/radius methods and xregrid
+        for conservative/bilinear. Force with ``"ckdtree"`` / ``"xregrid"``.
+
+    Returns
+    -------
+    xr.Dataset
+        Source data on the target grid.
+    """
+    
+    if backend == "auto":
+        if method in _CKDTREE_METHODS:
+            backend = "ckdtree"
+        elif method in _XREGRID_METHODS:
+            backend = "xregrid"
+        else:
+            raise NotImplementedError(
+                f"regrid: unknown method {method!r}. ckdtree: {_CKDTREE_METHODS}; "
+                f"xregrid: {_XREGRID_METHODS}."
+            )
+
+    if backend == "ckdtree":
+        src_lon = _resolve_coord_name(src, src_lon, _LON_NAMES, "longitude")
+        src_lat = _resolve_coord_name(src, src_lat, _LAT_NAMES, "latitude")
+        if not isinstance(target, dict) or "lon" not in target or "lat" not in target:
+            raise TypeError(
+                "regrid: target must be a dict with 'lon' and 'lat' array-likes. "
+                f"Got: {type(target).__name__}"
+            )
+        tlon = np.asarray(target["lon"])
+        tlat = np.asarray(target["lat"])
+        if tlon.shape != tlat.shape:
+            raise ValueError(
+                f"regrid: target lon shape {tlon.shape} != lat shape {tlat.shape}"
+            )
+        return _regrid_ckdtree(
+            src, src_lon, src_lat, tlon, tlat, target_dims,
+            method=method, max_distance=max_distance, radius=radius,
+        )
+
+    if backend == "xregrid":
+        return _regrid_xregrid(
+            src, target, method, src_grid=src_grid, target_grid=target_grid,
+        )
+
+    raise NotImplementedError(
+        f"regrid: backend={backend!r} not implemented. "
+        "Available: 'ckdtree', 'xregrid'."
+    )
+
+def _as_src_uxds(src, src_grid):
+    """Resolve a source to a UxDataset (clean uxgrid + data on n_face)."""
+    import uxarray as ux
+
+    if hasattr(src, "uxgrid") and src_grid is None:
+        return src
+
+    if src_grid is None:
+        raise ValueError(
+            "regrid (xregrid backend): conservative/bilinear on an "
+            "unstructured source needs src_grid=<SCRIP path or uxarray.Grid>, "
+            "or pass a UxDataset as src."
+        )
+    if isinstance(src_grid, str):
+        from melodies_monet.util.uxarray_util import open_uxgrid
+        uxgrid = open_uxgrid(src_grid)
+    else:
+        uxgrid = src_grid  # assume a uxarray.Grid
+
+    # Find the column dim whose length matches the mesh's n_face.
+    col_dim = None
+    for d, n in src.sizes.items():
+        if n == uxgrid.n_face:
+            col_dim = d
+            break
+    if col_dim is None:
+        raise ValueError(
+            f"regrid (xregrid backend): no src dim matches mesh n_face="
+            f"{uxgrid.n_face}. src dims: {dict(src.sizes)}."
+        )
+    src_ds = src if hasattr(src, "data_vars") else src.to_dataset()
+    if col_dim != "n_face":
+        src_ds = src_ds.rename({col_dim: "n_face"})
+    return ux.UxDataset(src_ds, uxgrid=uxgrid)
+
+def _coverage_normalize(out):
+    """Divide every regridded variable by the regridded ones-field.
+
+    The installed xregrid's conservative weights row-sum to ~2 instead of 1
+    (verified with two unit squares regridded onto themselves: a constant 1
+    comes back as exactly 2). Sigma(w*v)/Sigma(w*1) is the correct
+    area-weighted mean whatever the row scaling, so this is exact -- and a
+    harmless divide-by-1.0 if/when xregrid is fixed. Cells the source does
+    not reach get coverage 0/NaN and come out NaN, as they should.
+    """
+    global _COVERAGE_NOTICE_SHOWN
+    if "_mm_cov" not in getattr(out, "data_vars", {}):
+        return out
+    cov = out["_mm_cov"]
+    covd = cov.where(np.isfinite(cov) & (cov != 0))
+    _cm = float(np.nanmean(np.asarray(covd.values, dtype=float)))
+    if abs(_cm - 1.0) > 0.05 and not _COVERAGE_NOTICE_SHOWN:
+        _COVERAGE_NOTICE_SHOWN = True
+        print(f"regrid: xregrid weight row-sums ~{_cm:.2f} (known xregrid "
+              "0.1.0 bug); coverage-normalizing every conservative regrid "
+              "to a true area-weighted mean. Shown once per run.", flush=True)
+    for v in out.data_vars:
+        if v == "_mm_cov":
+            continue
+        attrs = out[v].attrs
+        out[v] = out[v] / covd
+        out[v].attrs = attrs
+    return out.drop_vars("_mm_cov")
+
+
+def _regrid_xregrid(src, target, method, src_grid=None, target_grid=None):
+    """xregrid/ESMF backend for conservative & bilinear regridding.
+
+    Source is resolved to a clean UxDataset. Target is either an
+    unstructured mesh (``target_grid``, e.g. a swath built from pixel
+    corner bounds) or a rectilinear grid from 1-D ``target`` lon/lat axes.
+    """
+    src_uxds = _as_src_uxds(src, src_grid)
+
+    # crash and say bilinear and patch cannot work with unstructured source
+    if method in ("bilinear", "patch") and hasattr(src_uxds, "uxgrid"):
+        raise ValueError(
+            f"regrid: method={method!r} is not supported for an unstructured "
+            "(cell-data) source. ESMF bilinear/patch interpolate from mesh "
+            "nodes, but the source values are on cell faces. Use "
+            "'conservative' (mass-conserving) instead, or a nearest method "
+            "via the ckdtree backend."
+        )
+
+    # --- Unstructured target (e.g. TEMPO swath). ---
+    if target_grid is not None:
+        # xregrid places output on whatever location the target carries data.
+        # An EMPTY UxDataset target makes it default to NODES (n_node), which
+        # is wrong for cell/face values. Seed the target with a face-located
+        # placeholder so the result lands on n_face; drop it afterward.
+        n_face = int(target_grid.n_face)
+        tgt_uxds = ux.UxDataset(
+            {"_mm_face_loc": (("n_face",), np.zeros(n_face, dtype="float32"))},
+            uxgrid=target_grid,
+        )
+        # A caller may pre-seed its OWN "_mm_cov" ones-field when it wants
+        # the raw (un-normalized) conservative sums plus the regridded
+        # coverage back -- e.g. _conservative_swath2mod_scan accumulates
+        # sum(raw_g)/sum(cov_g) across granules, a ratio that cancels the
+        # weight row scaling by itself. In that case skip both the
+        # injection and the internal normalization.
+        caller_cov = "_mm_cov" in src_uxds.data_vars
+        if not caller_cov:
+            src_uxds["_mm_cov"] = (
+                ("n_face",),
+                np.ones(int(src_uxds.sizes["n_face"]), dtype="float64"),
+            )
+            
+        try:
+            _ensure_xregrid_client()
+            rg = Regridder(src_uxds, tgt_uxds, method=method,
+                           parallel=_XREGRID_PARALLEL)
+            out = rg(src_uxds)
+            
+        # free memory
+            out = out.compute()
+            _release_esmf(rg)
+        finally:
+            if not caller_cov:
+                del src_uxds["_mm_cov"]
+
+        if hasattr(out, "data_vars") and "_mm_face_loc" in out.data_vars:
+            out = out.drop_vars("_mm_face_loc")
+        return out if caller_cov else _coverage_normalize(out)
+
+    # --- Rectilinear target from 1-D lon/lat axes. ---
+    if target is None:
+        raise ValueError(
+            "regrid (xregrid backend): provide either target_grid (mesh) or "
+            "target={'lon': 1d, 'lat': 1d} (rectilinear)."
+        )
+    tlon = np.asarray(target["lon"])
+    tlat = np.asarray(target["lat"])
+    
+    if tlon.ndim != 1 or tlat.ndim != 1:
+        raise NotImplementedError(
+            "regrid (xregrid backend): rectilinear target lon/lat must be 1-D "
+            f"(got shapes {tlon.shape}, {tlat.shape}). For a curvilinear "
+            "target, build a uxarray.Grid and pass target_grid instead."
+        )
+    target_ds = xr.Dataset(coords={"lon": ("lon", tlon), "lat": ("lat", tlat)})
+    caller_cov = "_mm_cov" in src_uxds.data_vars
+    if not caller_cov:
+        src_uxds["_mm_cov"] = (
+            ("n_face",), np.ones(int(src_uxds.sizes["n_face"]), dtype="float64")
+        )
+    try:
+        _ensure_xregrid_client()
+        rg = Regridder(src_uxds, target_ds, method=method, periodic=True,
+                       parallel=_XREGRID_PARALLEL)
+        out = rg(src_uxds).compute()
+        _release_esmf(rg)
+    finally:
+        if not caller_cov:
+            del src_uxds["_mm_cov"]
+    return out if caller_cov else _coverage_normalize(out)
+
+
+def _resolve_coord_name(obj, given, candidates, kind):
+    """Find a coord by name. Use ``given`` if set, else first candidate present."""
+    if given is not None:
+        if given not in obj.variables:
+            raise KeyError(
+                f"regrid: requested {kind} name {given!r} not in dataset. "
+                f"Available: {list(obj.variables)}"
+            )
+        return given
+    for c in candidates:
+        if c in obj.variables:
+            return c
+    raise KeyError(
+        f"regrid: no source {kind} found. Looked for {candidates}. "
+        f"Available: {list(obj.variables)}")
+
+
+def _regrid_ckdtree(
+    src, src_lon, src_lat, tlon, tlat, target_dims,
+    method="nearest_s2d", max_distance=None, radius=None,):
+    
+    """cKDTree backend.
+
+    Reuses :func:`melodies_monet.util.uxarray_util.sample_unstructured_at_points`,
+    which carries the cached KDTree (the same source grid hit across many
+    target queries — e.g. per-granule TEMPO loops — pays the build cost
+    once).
+    """
+    from melodies_monet.util.uxarray_util import sample_unstructured_at_points
+
+    # The helper hardcodes "longitude"/"latitude" internally. Rename src's
+    # coords if they use a different convention; restore on exit.
+    rename_in = {}
+    if src_lon != "longitude":
+        rename_in[src_lon] = "longitude"
+    if src_lat != "latitude":
+        rename_in[src_lat] = "latitude"
+    src_norm = src.rename(rename_in) if rename_in else src
+
+    target_shape = tlon.shape
+    tlon_flat = tlon.ravel()
+    tlat_flat = tlat.ravel()
+
+    if method == "radius_mean":
+        if radius is None:
+            raise ValueError(
+                "regrid: method='radius_mean' requires radius=<float deg>."
+            )
+        sampled = sample_unstructured_at_points(
+            src_norm, tlon_flat, tlat_flat, radius=radius,
+        )
+    elif method in ("nearest_s2d", "nearest_d2s"):
+        sampled = sample_unstructured_at_points(
+            src_norm, tlon_flat, tlat_flat, max_distance=max_distance,
+        )
+    else:
+        raise NotImplementedError(
+            f"regrid (ckdtree backend): method={method!r} not supported. "
+            "Use 'nearest_s2d', 'nearest_d2s', or 'radius_mean'."
+        )
+
+    # Resolve target_dims.
+    if target_dims is None:
+        if len(target_shape) == 1:
+            target_dims = ("target",)
+        else:
+            target_dims = tuple(f"dim_{i}" for i in range(len(target_shape)))
+    target_dims = tuple(target_dims)
+    if len(target_dims) != len(target_shape):
+        raise ValueError(
+            f"regrid: target_dims has length {len(target_dims)} but target "
+            f"shape is {target_shape}."
+        )
+
+    # Fast path: 1-D target with default name -- sample_unstructured_at_points
+    # already returns exactly this shape.
+    if len(target_shape) == 1 and target_dims == ("target",):
+        return sampled
+
+    # 1-D target with caller-chosen dim name: just rename.
+    if len(target_shape) == 1:
+        return sampled.rename({"target": target_dims[0]})
+
+    # N-D target: reshape every var's trailing "target" axis back to
+    # target_shape, then attach lon/lat as coords on the target dims.
+    out = xr.Dataset(attrs=dict(sampled.attrs))
+    for v in sampled.data_vars:
+        da = sampled[v]
+        if "target" not in da.dims:
+            out[v] = da
+            continue
+        transposed = da.transpose(..., "target")
+        arr = np.asarray(transposed.values)
+        new_shape = arr.shape[:-1] + target_shape
+        new_dims = transposed.dims[:-1] + target_dims
+        out[v] = xr.DataArray(
+            arr.reshape(new_shape), dims=new_dims, attrs=dict(da.attrs),
+        )
+
+    out = out.assign_coords({
+        "longitude": (target_dims, tlon),
+        "latitude": (target_dims, tlat),
+    })
+    return out

--- a/melodies_monet/util/sat_l2_swath_utility.py
+++ b/melodies_monet/util/sat_l2_swath_utility.py
@@ -14,6 +14,8 @@ import logging
 numba_logger = logging.getLogger('numba')
 numba_logger.setLevel(logging.WARNING)
 
+logger = logging.getLogger(__name__)
+
 def trp_interp_swatogrd(obsobj, modobj,no2varname='no2'):
 
     """
@@ -290,3 +292,922 @@ def cal_amf_wrfchem(scatw, wrfpreslayer, tpreslev, troppres, wrfno2layer_molec, 
 
     return ratio 
 
+# Conservative / unstructured TROPOMI NO2 operator (model -> TROPOMI column)
+# Reuses the model-agnostic regrid() (regrid_util) + uxarray helpers
+
+def _to_molmol(da):
+    """Return model mixing ratio in mol/mol, deciding by VALUE MAGNITUDE.
+
+    The CAM-unstructured reader scales NO2 to ppbV (~0.01-300) but can leave
+    the units attribute as 'mol/mol' (stale-attr bug). mol/mol NO2 is
+    ~1e-9-1e-7, so a max above ~1e-3 means the values are really ppbV.
+    """
+    mx = float(np.nanmax(np.abs(da.values)))
+    return da * 1e-9 if mx > 1e-3 else da
+
+def interp_vertical_mod2tropomi(obsobj, modobj_swath, variables=("NO2",)):
+    """Interpolate model mixing ratio (intensive) onto TROPOMI's layers.
+    
+    interpolate the model *concentration* in log-pressure onto those layers; the partial
+    column is integrated afterward (in :func:`apply_weights_mod2tropomi_no2`)
+    using TROPOMI's own layer thickness 
+    
+    Parameters
+    ----------
+    obsobj : xr.Dataset
+        One TROPOMI granule (time squeezed) with ``pres_pa_mid`` (z, y, x).
+    modobj_swath : xr.Dataset
+        Model already regridded to the swath pixels, with ``pres_pa_mid``
+        (z_mod, y, x) and the requested ``variables``.
+
+    Returns
+    -------
+    xr.Dataset
+        ``variables`` interpolated onto TROPOMI's z layers, dims (z, y, x).
+    """
+    
+    p_mod = np.asarray(modobj_swath["pres_pa_mid"].transpose("z", "y", "x").values)
+    p_trop = np.asarray(obsobj["pres_pa_mid"].transpose("z", "y", "x").values)
+    nz_t, ny, nx = p_trop.shape
+    out = xr.Dataset()
+    for var in list(variables):
+        src = np.asarray(modobj_swath[var].transpose("z", "y", "x").values)
+        dest = np.full((nz_t, ny, nx), np.nan, dtype=float)
+        for j in range(ny):
+            for i in range(nx):
+                mp = p_mod[:, j, i]; mc = src[:, j, i]; tp = p_trop[:, j, i]
+                good = np.isfinite(mp) & np.isfinite(mc)
+                if good.sum() < 2 or not np.isfinite(tp).any():
+                    continue
+                order = np.argsort(mp[good])
+                
+                # Edge behavior: CLAMP (np.interp default), matching TEMPO's
+                # _interp_vert. Retrieval levels below the model's lowest
+                # mid-level get the lowest-layer mixing ratio; levels above
+                # the model top get the top layer (tropopause-masked for
+                # tropospheric columns anyway). NaN edges here silently
+                # discarded ~85% of pixels: the retrieval surface level
+                # (~actual sfc pressure) usually sits below the model's
+                # lowest MID-level, so z=0 went NaN and the AK step's
+                # isfinite(vmr[0]) mask dropped the entire pixel.
+                dest[:, j, i] = np.interp(
+                    np.log10(tp), np.log10(mp[good][order]), mc[good][order],
+                    #left=np.nan, right=np.nan,
+                )
+        out[var] = xr.DataArray(dest, dims=("z", "y", "x"))
+    return out
+
+# regrid to lat lon 
+# In the future, this might need a seperate util file that enables it to be generalizeable to other sat products 
+_DEG_PER_M = 1.0 / 111320.0   # degrees latitude per metre (mean Earth)
+
+def _model_lonlat_extent(modobj, pad=0.0):
+    """(lonmin, lonmax, latmin, latmax) of the model domain, optionally padded"""
+    mlon = np.asarray(modobj["longitude"].values)
+    mlat = np.asarray(modobj["latitude"].values)
+    return (float(np.nanmin(mlon)) - pad, float(np.nanmax(mlon)) + pad,
+            float(np.nanmin(mlat)) - pad, float(np.nanmax(mlat)) + pad)
+
+def _crop_swath_to_extent(o, extent, pad=0.5):
+    """Slice a swath granule to the (y,x) index window overlapping the extent box.
+    """
+    if extent is None:
+        return o
+    lonmin, lonmax, latmin, latmax = extent
+    
+    lon_n = "longitude" if "longitude" in o.variables else "lon"  # TROPOMI vs TEMPO
+    lat_n = "latitude" if "latitude" in o.variables else "lat"
+    lon = np.asarray(o[lon_n].values)
+    lat = np.asarray(o[lat_n].values)
+    
+    inbox = ((lon >= lonmin - pad) & (lon <= lonmax + pad) &
+             (lat >= latmin - pad) & (lat <= latmax + pad))
+    if not inbox.any():
+        return None
+    hdims = o[lon_n].dims                      # (y, x) or (x, y)
+    a0 = np.where(inbox.any(axis=1))[0]
+    a1 = np.where(inbox.any(axis=0))[0]
+    sl = {hdims[0]: slice(int(a0.min()), int(a0.max()) + 1),
+          hdims[1]: slice(int(a1.min()), int(a1.max()) + 1)}
+    return o.isel(sl)
+
+def _swath2latlon(swath, data_vars, res, extent, units = "deg", method="radius_mean"):
+    """Regrid swath-paired fields (y, x) onto a regular lat/lon grid 
+
+    use radius mean averaging 
+    
+    returns a Dataset on dims (lat, lon).
+    """
+    from melodies_monet.util.regrid_util import regrid
+
+    lonmin, lonmax, latmin, latmax = extent
+    if units in ("km", "m"):
+        res_m = float(res) * 1000.0 if units == "km" else float(res)
+        dlat = res_m * _DEG_PER_M
+        midlat = 0.5 * (latmin + latmax)
+        dlon = res_m * _DEG_PER_M / max(np.cos(np.deg2rad(midlat)), 0.1)
+    else:  # degrees
+        dlat = dlon = float(res)
+
+    tlon1 = np.arange(lonmin, lonmax + dlon, dlon)
+    tlat1 = np.arange(latmin, latmax + dlat, dlat)
+    tlon2, tlat2 = np.meshgrid(tlon1, tlat1)        # (lat, lon)
+
+    # handle the lat lon naming between satellites 
+    # tropomi carry long / lat on (y,x) where tempo does lon / lat on (x,y)
+    # rename to longintude latitude 
+    ren = {}
+    if "longitude" not in swath.variables and "lon" in swath.variables:
+        ren["lon"] = "longitude"
+    if "latitude" not in swath.variables and "lat" in swath.variables:
+        ren["lat"] = "latitude"
+    if ren:
+        swath = swath.rename(ren)
+    _to_coord = [c for c in ("longitude", "latitude") if c in swath.data_vars]
+    if _to_coord:
+        swath = swath.set_coords(_to_coord)
+
+    # insert a conservative regriding option 
+    # Builds the swath source mesh from corner bounds and a rectilinear target
+    # mesh, then mesh-to-mesh conservative regrid
+    # Fall back to radius_mean if bounds are missing
+    
+    if method in _CONSERVATIVE and "longitude_bounds" in swath.variables:
+        try:
+            import uxarray as ux
+
+            swath_grid, _ = _tropomi_swath_mesh(swath)
+            _hd = tuple(swath["longitude"].dims)
+            _flat = (
+                swath[data_vars].stack(n_face=_hd).reset_index("n_face", drop=True)
+            )
+            _flat = _flat.drop_vars(
+                [c for c in _flat.coords if "n_face" in _flat[c].dims], errors="ignore")
+            _src = ux.UxDataset(_flat, uxgrid=swath_grid)
+            _tgt = ux.Grid.from_structured(lon=tlon1, lat=tlat1)
+            _out = regrid(_src, method=method, target_grid=_tgt)
+            _out = _out.where(_out != 0)        # empty cells go to  NaN, not 0
+
+            _nlat, _nlon = tlat1.size, tlon1.size
+            _ncell = _nlat * _nlon
+            _fd = next((d for d in _out.dims if _out.sizes.get(d) == _ncell), None)
+            if _fd is None:
+                raise ValueError("conservative target face dim not found after regrid")
+            _res = xr.Dataset()
+            for v in _out.data_vars:
+                da = _out[v]
+                if _fd not in da.dims:
+                    continue
+                t = da.transpose(..., _fd)
+                arr = np.asarray(t.values).reshape(t.shape[:-1] + (_nlat, _nlon))
+                _res[v] = xr.DataArray(arr, dims=t.dims[:-1] + ("y", "x"),
+                                       attrs=dict(da.attrs))
+            return _res.assign_coords(
+                longitude=(("y", "x"), tlon2), latitude=(("y", "x"), tlat2),
+                x=("x", tlon1), y=("y", tlat1))
+        except Exception as e:
+            print(f"_swath2latlon: conservative regrid failed ({e!r}); "
+                  "falling back to radius_mean.", flush=True)
+
+    hdims = list(swath["longitude"].dims)            # (y, x) or (x, y)
+
+    # instead of radius mean use a box mean gridding (faster)
+    
+    # flat = (
+    #     swath[data_vars]
+    #     .stack(pixel=hdims)
+    #     .reset_index("pixel", drop=True)
+    # )
+
+    plon = np.asarray(swath["longitude"].values).ravel()
+    plat = np.asarray(swath["latitude"].values).ravel()
+    nlat, nlon = tlat1.size, tlon1.size
+    ncell = nlat * nlon
+    
+    # search radius ~ cell size, but at least ~5 km (sensor footprint) so a
+    # finer-than-sensor grid fills from the nearest pixel instead of going empty.
+    # radius = max(float(dlat), 0.05)
+    # out = regrid(flat, target={"lon": tlon2, "lat": tlat2},
+    #              method="radius_mean", radius=radius, target_dims=("lat", "lon"))
+    # out = out.where(out != 0)        # empty cells -> NaN, not 0
+
+    # out = out.assign_coords(lon=("lon", tlon1), lat=("lat", tlat1))
+    ix = np.floor((plon - lonmin) / dlon).astype(np.intp)
+    iy = np.floor((plat - latmin) / dlat).astype(np.intp)
+    ingrid = ((ix >= 0) & (ix < nlon) & (iy >= 0) & (iy < nlat)
+              & np.isfinite(plon) & np.isfinite(plat))
+    cell = iy * nlon + ix                            # flat (lat-major) cell id
+    
+    out = xr.Dataset()
+    for v in data_vars:
+        da = swath[v]
+        extra = [d for d in da.dims if d not in hdims]
+        arr = np.asarray(da.transpose(*extra, *hdims).values, dtype=float).reshape(-1, plon.size)
+        res = np.full((arr.shape[0], ncell), np.nan)
+        for k in range(arr.shape[0]):
+            good = ingrid & np.isfinite(arr[k])
+            c = cell[good]
+            ssum = np.bincount(c, weights=arr[k][good], minlength=ncell)
+            scnt = np.bincount(c, minlength=ncell)
+            with np.errstate(invalid="ignore", divide="ignore"):
+                m = ssum / scnt
+            m[scnt == 0] = np.nan
+            res[k] = m
+        out[v] = xr.DataArray(
+            res.reshape(tuple(da.sizes[d] for d in extra) + (nlat, nlon)),
+            dims=tuple(extra) + ("y", "x"), attrs=dict(da.attrs))
+
+    # 2-D lon/lat + 1-D x/y so the result flows through structured-sat plotting
+    return out.assign_coords(
+        longitude=(("y", "x"), tlon2), latitude=(("y", "x"), tlat2),
+        x=("x", tlon1), y=("y", tlat1))
+
+    # # want to make sure these regrided lat lon pairs can just run through the existing plotting 
+    # return out.rename({"lat": "y", "lon": "x"})
+
+def _wmean(da, w):
+    """Weighted spatial mean of da with weights w, ignoring NaN
+
+    Returns a 0-d (scalar) DataArray; NaN if nothing valid.
+    """
+    w = w.where(np.isfinite(da) & np.isfinite(w) & (w > 0))
+    den = w.sum(skipna=True)
+    return xr.where(den > 0, (da * w).sum(skipna=True) / den, np.nan)
+
+def _attach_obs_err(swath, o, obs_var):
+    """Attach the per-pixel retrieval error to swath as _obs_err
+    
+    Used by the 'series' target to inverse-variance weight the observations
+    
+    Looks for '<obs_var>_precision' then '<obs_var>_uncertainty' in the
+    granule. No-op if neither was read in (then 'series' falls back to area
+    weighting for obs).
+    
+    """
+    for _name in (obs_var + "_precision", obs_var + "_uncertainty"):
+        if _name in o.variables:
+            err = o[_name]
+            if "time" in err.dims:
+                err = err.squeeze("time", drop=True)
+            swath["_obs_err"] = err
+            return
+
+def _swath2series(swath, data_vars, obs_var=None,
+                  obs_weight="inverse_variance", model_weight="area"):
+    
+    """Collapse a swath to ONE weighted domain value per variable (a time point).
+
+    The 'series' target saves a *time vector* instead of a map: every
+    granule/overpass is reduced to a single representative number, and the
+    orchestrator stamps it with the overpass time and concatenates to (time,).
+    Obs and model are reduced over the *same* sampled pixels, so they stay
+    directly comparable (the absolute level still reflects which footprint each
+    overpass sampled).
+
+    Default weighting:
+      * model field        -> AREA-weighted by cos(latitude), so the domain
+        mean is area-representative rather than biased toward where swath
+        pixels happen to be dense.
+      * obs field (obs_var) -> INVERSE-VARIANCE weighted (weight = 1/sigma^2)
+        using the per-pixel retrieval error in swath['_obs_err'] (see
+        _attach_obs_err), so noisy retrievals count for less. Falls back to
+        area weighting if no error field is attached.
+
+    obs_weight / model_weight may be overridden: 'inverse_variance' | 'area'
+    | 'equal'. Returns a Dataset of scalars (one per variable in data_vars).
+    """
+    
+    lat = swath["latitude"] if "latitude" in swath.variables else swath["lat"]
+    w_area = np.cos(np.deg2rad(lat))
+
+    out = xr.Dataset()
+    for v in data_vars:
+        da = swath[v]
+        mode = obs_weight if v == obs_var else model_weight
+        if v == obs_var and mode == "inverse_variance" and "_obs_err" in swath.variables:
+            out[v] = _wmean(da, 1.0 / (swath["_obs_err"] ** 2))   # inverse-variance
+            used = "inverse_variance"
+        elif mode == "equal":
+            out[v] = da.mean(skipna=True)                          # unweighted
+            used = "equal"
+        else:
+            out[v] = _wmean(da, w_area)                            # area (cos lat)
+            # requested inverse_variance but no _obs_err read in to area
+            used = ("area (inverse_variance fallback: no _obs_err)"
+                    if v == obs_var and mode == "inverse_variance" else "area")
+        # record how this scalar was built so saved series files are auditable
+        out[v].attrs = {**dict(da.attrs), "series_weighting": used}
+        
+    return out
+
+def _swath_to_target(swath, modobj, method, data_vars, target, res, extent, units="deg" ):
+    """Regrid the paired swath onto the requested target space
+
+    if target = model, use model's native unstructured grid via tropomi_swath2mod
+
+    if target = obs, use a regular lat lon grid via _swath2latlon 
+
+    if target = series, single weighted domain value per overpass (time vector)
+
+    """
+    if target == "model":
+        return _tropomi_swath2mod(swath, modobj, method, data_vars)
+    if target == "obs":
+        return _swath2latlon(swath, data_vars, res, extent, units=units, method=method)
+    if target == "series":
+        _ov = data_vars[1] if len(data_vars) > 1 else None
+        return _swath2series(swath, data_vars, obs_var=_ov)
+    raise ValueError(f"regrid_target {target!r} not understood; use 'model', 'obs', or 'series'.")
+
+def apply_weights_mod2tropomi_no2(obsobj, modobj_on_tropomi_layers, species="NO2"):
+    """Apply the TROPOMI averaging kernel to a model NO2 profile.
+
+    Mirrors :func:`apply_weights_mod2tempo_no2` but uses TROPOMI's
+    averaging kernel instead of scattering weights:
+
+      AK_trop = averaging_kernel * (amf_total / amf_troposphere)
+      subcol  = vmr * (dp/g) * (NA/M_air) / 1e4         # molec/cm2 per layer
+      VCD     = sum over tropospheric layers (p >= tropopause) of AK_trop*subcol
+
+    Parameters
+    ----------
+    obsobj : xr.Dataset
+        One TROPOMI granule (time squeezed): averaging_kernel (z,y,x),
+        air_mass_factor_troposphere/_total (y,x), pres_pa_mid (z,y,x),
+        pres_pa_int (z_stagg,y,x), tm5_tropopause_pressure (y,x).
+    modobj_on_tropomi_layers : xr.Dataset
+        Model ``species`` mixing ratio on TROPOMI's z layers (z,y,x), from
+        :func:`interp_vertical_mod2tropomi`. Units auto-detected (ppbV/mol/mol).
+
+    Returns
+    -------
+    xr.DataArray
+        Model NO2 tropospheric column with the AK applied, molec/cm2, (y, x).
+    """
+    g, M_air, NA = 9.80665, 0.0289644, 6.022e23
+
+    vmr = _to_molmol(modobj_on_tropomi_layers[species]).transpose("z", "y", "x")
+    pint = obsobj["pres_pa_int"].transpose("z_stagg", "y", "x")
+    dp = np.abs(
+        pint.isel(z_stagg=slice(0, -1)).values
+        - pint.isel(z_stagg=slice(1, None)).values
+    )
+    dp = xr.DataArray(dp, dims=("z", "y", "x"))
+    subcol = vmr * dp * (NA / (g * M_air) / 1e4)            # molec/cm2 per layer
+
+    ak = obsobj["averaging_kernel"].transpose("z", "y", "x")
+    ak_trop = ak * (obsobj["air_mass_factor_total"]
+                    / obsobj["air_mass_factor_troposphere"])
+    trop = (obsobj["pres_pa_mid"].transpose("z", "y", "x")
+            >= obsobj["tm5_tropopause_pressure"])
+
+    vcd = (ak_trop * subcol).where(trop).sum("z", skipna=True)
+    vcd = vcd.where(np.isfinite(vmr.isel(z=0)))
+
+    # AK sanity diagnostic (enable with logging DEBUG): AK/raw equals
+    # AMF_model/AMF_retrieval. This one-liner exposed the xregrid doubling.
+    if logger.isEnabledFor(logging.DEBUG):
+        try:
+            raw = subcol.where(trop).sum("z", skipna=True)
+            ratio = (vcd / raw).where(raw != 0)
+            logger.debug(
+                "[AK] TROPOMI %s: raw_col=%.2e AK-applied=%.2e AK/raw=%.2f "
+                "(=AMF_mod/AMF_ret)", species,
+                float(np.nanmean(raw.values)), float(np.nanmean(vcd.values)),
+                float(np.nanmean(ratio.values)))
+        except Exception as e:  # noqa: BLE001
+            logger.debug("[AK] TROPOMI %s ratio diag skipped: %r", species, e)
+        
+    vcd.attrs = {
+        "units": "molecules/cm2",
+        "description": "model NO2 tropospheric column after applying TROPOMI averaging kernel",
+        "history": "Created by MELODIES-MONET, apply_weights_mod2tropomi_no2",
+    }
+    return vcd.where(np.isfinite(vcd))
+
+# Orchestrator: conservative/unstructured TROPOMI NO2 pairing.
+# Mirrors the TEMPO regrid_and_apply_weights flow but with the TROPOMI
+# averaging-kernel operator. Reuses only the shared, product-agnostic regrid
+# primitives (regrid_util.regrid, uxarray_util.open_uxgrid /
+# uxgrid_from_corner_bounds) -- no dependency on the TEMPO utility.
+
+_TROPOMI_NO2_VAR = "nitrogendioxide_tropospheric_column"
+_MOL_M2_TO_MOLEC_CM2 = 6.02214e19
+_CONSERVATIVE = ("conservative", "conservative_normed")
+
+def _tropomi_swath_mesh(o):
+    """Build a uxarray Grid from a TROPOMI granule's pixel corner bounds.
+
+    Returns (grid, (ny, nx)). Flatten order is row-major over (y, x), matching
+    how the n_face result is reshaped back.
+    """
+    from melodies_monet.util.uxarray_util import uxgrid_from_corner_bounds
+
+    olon = np.asarray(o["longitude"].values)  # (y, x)
+    ny, nx = olon.shape
+    clon = np.asarray(o["longitude_bounds"].values).reshape(ny * nx, -1)
+    clat = np.asarray(o["latitude_bounds"].values).reshape(ny * nx, -1)
+    return uxgrid_from_corner_bounds(clon, clat), (ny, nx)
+
+
+def _mod2tropomi_swath(modobj, o, method, mod_vars, grid_file):
+    """Regrid model fields onto the TROPOMI swath pixels (y, x).
+
+    conservative -> mesh-to-mesh via xregrid (model SCRIP/MPAS mesh -> swath
+    cells from bounds); nearest/radius -> cKDTree at pixel centers. Returns a
+    Dataset with each requested var on (..., y, x).
+    """
+    from melodies_monet.util.regrid_util import regrid
+
+    msrc = modobj[[v for v in mod_vars if v in modobj.variables]]
+    olon = np.asarray(o["longitude"].values)
+    olat = np.asarray(o["latitude"].values)
+    ny, nx = olon.shape
+
+    if method in _CONSERVATIVE:
+        from melodies_monet.util.uxarray_util import (
+            faces_to_grid, subset_model_source)
+
+        swath_grid, _ = _tropomi_swath_mesh(o)
+        # Subset the model mesh to the swath bbox before building conservative
+        # weights (far faces contribute zero). Mirrors the TEMPO forward path.
+        src, src_grid = subset_model_source(
+            msrc, grid_file,
+            float(np.nanmin(olon)), float(np.nanmax(olon)),
+            float(np.nanmin(olat)), float(np.nanmax(olat)),
+            label="_mod2tropomi_swath",
+        )
+        out = regrid(src, method=method, src_grid=src_grid,
+                     target_grid=swath_grid)
+
+        res = faces_to_grid(out, (ny, nx), ("y", "x"))
+        return res.assign_coords(longitude=(("y", "x"), olon),
+                                 latitude=(("y", "x"), olat))
+
+    # nearest family
+    out = regrid(msrc, target={"lon": olon, "lat": olat},
+                 method="nearest_s2d", target_dims=("y", "x"))
+    return out
+
+
+def _tropomi_swath2mod(swath, modobj, method, data_vars):
+    """Regrid swath-paired fields (y, x) onto the unstructured model columns.
+
+    conservative -> mesh-to-mesh via xregrid (swath cells -> model mesh);
+    else -> cKDTree within-radius mean. Returns a Dataset on the model
+    column dim with longitude/latitude attached.
+    """
+    import uxarray as ux
+    from melodies_monet.util.regrid_util import regrid
+    from melodies_monet.util.uxarray_util import open_uxgrid
+
+    col_dim = modobj["longitude"].dims[0]
+    mlon = np.asarray(modobj["longitude"].values).ravel()
+    mlat = np.asarray(modobj["latitude"].values).ravel()
+    grid_file = (modobj.attrs.get("mio_scrip_file")
+                 or modobj.attrs.get("mio_mesh_file"))
+
+    if method in _CONSERVATIVE and "longitude_bounds" in swath.variables:
+        from melodies_monet.util.uxarray_util import (
+            flatten_to_faces, subset_mesh_to_bbox)
+        swath_grid, (ny, nx) = _tropomi_swath_mesh(swath)
+        flat = flatten_to_faces(swath[data_vars], ("y", "x"))
+        src = ux.UxDataset(flat, uxgrid=swath_grid)
+        model_grid = open_uxgrid(grid_file)
+        n_col = int(model_grid.n_face)
+
+        # Subset the TARGET mesh to the swath bbox before building weights, then
+        # scatter results back to the full mesh (faces outside the swath go NaN).
+        # Mirrors the TEMPO backward path.
+        out = None
+        try:
+            _slon = np.asarray(swath["longitude"].values)
+            _slat = np.asarray(swath["latitude"].values)
+            _keep, _subgrid = subset_mesh_to_bbox(
+                grid_file,
+                float(np.nanmin(_slon)), float(np.nanmax(_slon)),
+                float(np.nanmin(_slat)), float(np.nanmax(_slat)))
+            if _subgrid is not None:
+                out_sub = regrid(src, method=method, target_grid=_subgrid)
+                _sfd = next((d for d in out_sub.dims
+                             if out_sub.sizes[d] == _keep.size), None)
+                out = xr.Dataset(attrs=dict(out_sub.attrs))
+                for v in out_sub.data_vars:
+                    da = out_sub[v]
+                    if _sfd is None or _sfd not in da.dims:
+                        out[v] = da
+                        continue
+                    da = da.transpose(..., _sfd)
+                    arr = np.asarray(da.values)
+                    full = np.full(arr.shape[:-1] + (n_col,), np.nan, dtype="float64")
+                    full[..., _keep] = arr
+                    out[v] = xr.DataArray(full, dims=da.dims[:-1] + (_sfd,),
+                                          attrs=dict(da.attrs))
+                print(f"_tropomi_swath2mod: target mesh subset {n_col} -> "
+                      f"{_keep.size} faces", flush=True)
+        except Exception as e:  # noqa: BLE001
+            print(f"_tropomi_swath2mod: target subset skipped ({e!r}); full mesh.",
+                  flush=True)
+            out = None
+        if out is None:
+            out = regrid(src, method=method, target_grid=model_grid)
+            
+        # Conservative regrid fills model cells with no swath overlap with exactly 0.
+        out = out.where(out != 0)
+        
+        # n_col = int(model_grid.n_face)
+        d = next((dd for dd in out.dims if out.sizes[dd] == n_col), None)
+        if d is not None and d != col_dim:
+            out = out.rename({d: col_dim})
+        return out.assign_coords({"longitude": (col_dim, mlon),
+                                  "latitude": (col_dim, mlat)})
+
+    # nearest / radius_mean fallback
+    flat = (
+        swath[data_vars]
+        .stack(pixel=("y", "x"))
+        .reset_index("pixel", drop=True)
+        .set_coords(["longitude", "latitude"])
+    )
+    out = regrid(flat, target={"lon": mlon, "lat": mlat},
+                 method="radius_mean", radius=0.1, target_dims=(col_dim,))
+
+    # make sure to fill 0s with nans
+    return out.where(out != 0)
+
+# 07062026 simplify this code and combine where redundant 
+
+# time should be non specific to the satellite 
+def _granule_time(o):
+    """Granule overpass time for model matching.
+
+    Prefer 'time_granule' (real per-measurement times, take the mean); fall
+    back to the 'time' coord (start-of-day reference) if absent. None if
+    neither is usable.
+    """
+    if "time_granule" in o.variables:
+        tg = np.asarray(o["time_granule"].values).ravel().astype("datetime64[ns]")
+        tg = tg[~np.isnat(tg)]
+        return (np.array(tg.astype("int64").mean(), dtype="int64")
+                .astype("datetime64[ns]") if tg.size else None)
+    return o["time"].values if "time" in o.coords else None
+    
+# model time at the granule sat overpass time 
+def _model_at_time(modobj, gtime):
+    """Model state at a granule's overpass time.
+
+    Linear time interpolation, clamped to the model's time span (an overpass
+    just outside the model window snaps to the first/last model time);
+    nearest-neighbor as a fallback; passthrough when the model has no time
+    dim (or first step when the overpass time is unknown).
+    """
+    if "time" not in modobj.dims:
+        return modobj
+    if gtime is None:
+        return modobj.isel(time=0)
+    tsel = gtime if np.ndim(gtime) == 0 else np.asarray(gtime).ravel()[0]
+    mtimes = modobj["time"].values
+    tsel = min(max(tsel, mtimes.min()), mtimes.max())
+    try:
+        return modobj.interp(time=tsel)
+    except Exception:
+        return modobj.sel(time=tsel, method="nearest")
+
+
+###################### Regrid and application of weights ###################### 
+########################### instrument specific ############################### 
+
+def regrid_and_apply_weights_tropomi(obsobj, modobj, species=["NO2"],
+                                     method="conservative", qa_min=0.75,
+                                     regrid_target="model", obs_grid_res=0.1, obs_grid_units="deg", obs_grid_extent=None, 
+                                     save_vars=None):
+    
+    """Pair an unstructured model with TROPOMI L2 NO2 (AK applied).
+
+    wrapper for _pair_tropomi. for each granule, forward regrid model to the swath, interpolate model profile 
+    onto tropomi layers, apple the AK, then regrid the AK'd model column AND obs column to requested 
+    regrid targets. Concatenated along time 
+
+    Parameters
+    ----------
+    obsobj : dict[str, list[xr.Dataset]]
+        Output of the generic TROPOMI reader (tropomi_l2.open_datasets):
+        keyed by date, each value a list of orbit granules.
+    modobj : xr.Dataset
+        Unstructured model with longitude/latitude on its column dim,
+        NO2 (ppbV or mol/mol), pres_pa_mid, and mio_scrip_file/mio_mesh_file.
+    species : list[str]
+        Model species name(s); species[0] is paired.
+    method : str
+        Regrid method (conservative recommended; nearest_s2d/radius_mean ok).
+
+    Returns
+    -------
+    dict[str, xr.Dataset]
+        Per regrid target: paired model + obs NO2 tropospheric columns
+        (molec/cm2), stacked along ``time`` (one entry per granule).
+    """
+    
+    return _pair_tropomi("no2", obsobj, modobj, species=species, method=method,
+                         qa_min=qa_min, regrid_target=regrid_target,
+                         obs_grid_res=obs_grid_res,
+                         obs_grid_units=obs_grid_units,
+                         obs_grid_extent=obs_grid_extent, save_vars=save_vars)
+    
+# tropomi HCHO 
+# single tropo AMF and total columng averaging kernel 
+# use generic tropomi_l2 reader + shared regrid / interp 
+
+def apply_weights_mod2tropomi_hcho(obsobj, modobj_on_tropomi_layers, species="CH2O"):
+    """Apply the TROPOMI HCHO averaging kernel to a model formaldehyde profile.
+
+    Returns the model HCHO column with the AK applied (molec/cm2), dims (y, x).
+    """
+    g, M_air, NA = 9.80665, 0.0289644, 6.022e23
+
+    vmr = _to_molmol(modobj_on_tropomi_layers[species]).transpose("z", "y", "x")
+
+    pint = obsobj["pres_pa_int"].transpose("z_stagg", "y", "x")
+    dp = np.abs(
+        pint.isel(z_stagg=slice(0, -1)).values
+        - pint.isel(z_stagg=slice(1, None)).values
+    )
+    dp = xr.DataArray(dp, dims=("z", "y", "x"))
+    subcol = vmr * dp * (NA / (g * M_air) / 1e4)            # molec/cm2 per layer
+
+    # AK * AMF 
+    ak = obsobj["averaging_kernel"].transpose("z", "y", "x")
+    ak = ak * obsobj["formaldehyde_tropospheric_air_mass_factor"] # hopefully this isnt hardcoded otherwise will need to pull this in from YAML
+
+    vcd = (ak * subcol).sum("z", skipna=True)
+    vcd = vcd.where(np.isfinite(vmr.isel(z=0)))
+    
+    vcd.attrs = {
+        "units": "molecules/cm2",
+        "description": "model HCHO column after applying TROPOMI averaging kernel",
+        "history": "Created by MELODIES-MONET, apply_weights_mod2tropomi_hcho",
+    }
+    return vcd.where(np.isfinite(vcd))
+
+def regrid_and_apply_weights_tropomi_hcho(obsobj, modobj, species=["CH2O"],
+                                          method="conservative", qa_min=0.5,
+                                          regrid_target="model", obs_grid_res=0.1, obs_grid_units="deg", 
+                                          obs_grid_extent=None, save_vars = None):
+    """
+    Pair an unstructured model with TROPOMI L2 HCHO (AK applied).
+
+    defaults to regridding to model space via "regrid_target"
+
+    regrid_target="model" ; model space 
+    regrid_target="obs" ; obs space
+    regrid_target="series" ; one weighted domain value per overpass
+    
+    """
+    return _pair_tropomi("hcho", obsobj, modobj, species=species, method=method,
+                         qa_min=qa_min, regrid_target=regrid_target,
+                         obs_grid_res=obs_grid_res,
+                         obs_grid_units=obs_grid_units,
+                         obs_grid_extent=obs_grid_extent, save_vars=save_vars)
+
+# co 
+_TROPOMI_CO_VAR = "carbonmonoxide_total_column"
+
+def apply_weights_mod2tropomi_co(obsobj, modobj_on_tropomi_layers, species="CO"):
+    """Apply the TROPOMI CO column averaging kernel to a model CO profile.
+
+    """
+    g, M_air, NA = 9.80665, 0.0289644, 6.022e23
+
+    vmr = _to_molmol(modobj_on_tropomi_layers[species]).transpose("z", "y", "x")
+
+    pint = obsobj["pres_pa_int"].transpose("z_stagg", "y", "x")
+    dp = np.abs(
+        pint.isel(z_stagg=slice(0, -1)).values
+        - pint.isel(z_stagg=slice(1, None)).values
+    )
+    dp = xr.DataArray(dp, dims=("z", "y", "x"))
+    subcol = vmr * dp * (NA / (g * M_air) / 1e4)            # molec/cm2 per layer
+
+    ak = obsobj["column_averaging_kernel"].transpose("z", "y", "x")  # dimensionless 
+    vcd = (ak * subcol).sum("z", skipna=True)
+    vcd = vcd.where(np.isfinite(vmr.isel(z=0)))
+    
+    vcd.attrs = {
+        "units": "molecules/cm2",
+        "description": "model CO column after applying TROPOMI column averaging kernel",
+        "history": "Created by MELODIES-MONET, apply_weights_mod2tropomi_co",
+    }
+    return vcd.where(np.isfinite(vcd))
+
+def regrid_and_apply_weights_tropomi_co(obsobj, modobj, species=["CO"],
+                                        method="conservative", qa_min=0.5,
+                                        regrid_target="model", obs_grid_res=0.1, obs_grid_units="deg", obs_grid_extent=None, 
+                                        save_vars=None):
+    """Pair an unstructured model with TROPOMI L2 CO (column AK applied).
+
+    Thin wrapper over _pair_tropomi('co', ...). Prefers the destriped
+    'carbonmonoxide_total_column_corrected' when it was read in.
+    """
+    return _pair_tropomi("co", obsobj, modobj, species=species, method=method,
+                         qa_min=qa_min, regrid_target=regrid_target,
+                         obs_grid_res=obs_grid_res,
+                         obs_grid_units=obs_grid_units,
+                         obs_grid_extent=obs_grid_extent, save_vars=save_vars)
+
+
+
+# generalize the ability to easily add more tropomi species 
+# to add new satelite variables ncdump -h "$F" | grep -iE "group: (PRODUCT|DETAILED_RESULTS|INPUT_DATA)|carbonmonoxide_total_column|column_averaging_kernel|pressure_levels|qa_value|layer =|:units|:multiplication_factor"
+
+_TROPOMI_PRODUCTS = {
+    "no2": dict(obs_var="nitrogendioxide_tropospheric_column",
+                ak_apply=apply_weights_mod2tropomi_no2,
+                species="NO2", qa_min=0.75, prefer_corrected=False),
+    "hcho": dict(obs_var="formaldehyde_tropospheric_vertical_column",
+                 ak_apply=apply_weights_mod2tropomi_hcho,
+                 species="CH2O", qa_min=0.5, prefer_corrected=False),
+    "co": dict(obs_var="carbonmonoxide_total_column",
+               ak_apply=apply_weights_mod2tropomi_co,
+               species="CO", qa_min=0.5, prefer_corrected=True),
+}
+
+def _tropomi_swath_pixels(swath, sp, obs_var, gtime, save_vars=None):
+    """Flatten one paired TROPOMI granule to a native-pixel vector.
+
+    The 'swath' target keeps every footprint (no gridding): a 1-D ``obs``
+    vector carrying longitude/latitude/time as per-pixel coords, plus the
+    per-pixel retrieval uncertainty (renamed ``<obs_var>_uncertainty``).
+    All-NaN pixels dropped.
+    """
+    sdims = tuple(swath[obs_var].dims)                       # (y, x)
+
+    # can save out QA values 
+    _extra = [v for v in (save_vars or []) if v in swath.variables]
+    keep_vars = ([sp, obs_var]
+                 + (["_obs_err"] if "_obs_err" in swath.variables else [])
+                 + _extra)
+    
+    flat = swath[keep_vars].stack(obs=sdims).reset_index("obs", drop=True)
+    lon = np.asarray(
+        swath["longitude"].stack(obs=sdims).reset_index("obs", drop=True).values)
+    lat = np.asarray(
+        swath["latitude"].stack(obs=sdims).reset_index("obs", drop=True).values)
+    n = flat.sizes["obs"]
+    _t = (np.datetime64(gtime if np.ndim(gtime) == 0
+                        else np.asarray(gtime).ravel()[0])
+          if gtime is not None else np.datetime64("NaT"))
+    flat = flat.assign_coords(longitude=("obs", lon), latitude=("obs", lat),
+                              time=("obs", np.full(n, _t)))
+    if "_obs_err" in flat.data_vars:
+        flat = flat.rename({"_obs_err": obs_var + "_uncertainty"})
+        
+    # carry pixel CORNER bounds (obs, corner) for footprint-polygon rendering
+    for _bn in ("longitude_bounds", "latitude_bounds"):
+        if _bn in swath.variables:
+            _bb = swath[_bn].stack(obs=sdims).reset_index("obs", drop=True)
+            _cd = next((d for d in _bb.dims if d != "obs"), None)
+            if _cd is not None:
+                flat[_bn] = _bb.transpose("obs", _cd)
+                
+    keep = np.zeros(n, dtype=bool)
+    for v in (sp, obs_var):
+        if v in flat.data_vars:
+            keep |= np.isfinite(np.asarray(flat[v].values))
+    return flat.isel(obs=np.where(keep)[0])
+
+
+def _pair_tropomi(product, obsobj, modobj, species=None, method="conservative",
+                  qa_min=None, regrid_target="model", obs_grid_res=0.1,
+                  obs_grid_units="deg", obs_grid_extent=None, save_vars = None):
+    
+    """Shared TROPOMI pairing loop; the per-product science comes from
+    _TROPOMI_PRODUCTS[product].
+
+    For each granule: crop to the domain extent (if specified), take the model at the
+    overpass time, forward-regrid model to the swath, interpolate to the
+    retrieval layers, apply the averaging kernel, QA-filter obs and model
+    together, then regrid the paired swath to every requested target
+    ('model' / 'obs' / 'series'), stamp it with the overpass time and
+    concatenate along time.
+    """
+    
+    cfg = _TROPOMI_PRODUCTS[product]
+    obs_var = cfg["obs_var"]
+    sp = (species or [cfg["species"]])[0]
+    if qa_min is None:
+        qa_min = cfg["qa_min"]
+    save_vars = list(save_vars or [])
+
+    grid_file = (modobj.attrs.get("mio_scrip_file")
+                 or modobj.attrs.get("mio_mesh_file"))
+
+    targets = [regrid_target] if isinstance(regrid_target, str) else list(regrid_target)
+    extent = (tuple(obs_grid_extent) if obs_grid_extent
+              else _model_lonlat_extent(modobj))
+
+    # Flatten dict[date -> list[granule]] to a flat granule list.
+    granules = []
+    for v in obsobj.values():
+        granules.extend(v if isinstance(v, list) else [v])
+
+    # warn once when the product has a destriped column but only the raw
+    # (stripey) one was read in
+    # this particularly seems to affect the CO product. 
+    if cfg["prefer_corrected"]:
+        if not any(obs_var + "_corrected" in o.variables for o in granules):
+            print(f"TROPOMI {product}: pairing the raw (stripey) column. The "
+                  f"product ships a destriped variable -- add "
+                  f"'{obs_var}_corrected: {{}}' to the obs variables in the "
+                  "control YAML.", flush=True)
+
+    out_by = {t: [] for t in targets}
+
+    # warn about heavy 3d vars saving out 
+    _warned_3d = False
+    
+    for o in granules:
+        if "time" in o.dims:
+            o = o.squeeze("time", drop=False)
+
+        # crop the orbit to the region of interest before the expensive pairing
+        o = _crop_swath_to_extent(o, extent)
+        if o is None:
+            continue
+
+        gtime = _granule_time(o)
+        mod_t = _model_at_time(modobj, gtime)
+
+        # model to swath to retrieval layers to AK-applied column (molec/cm2)
+        on_swath = _mod2tropomi_swath(mod_t, o, method, [sp, "pres_pa_mid"],
+                                      grid_file)
+        prof_t = interp_vertical_mod2tropomi(o, on_swath, [sp])
+
+        model_col = cfg["ak_apply"](o, prof_t, sp)
+
+        src = (obs_var + "_corrected"
+               if cfg["prefer_corrected"] and obs_var + "_corrected" in o.variables
+               else obs_var)
+        obs_col = o[src] * _MOL_M2_TO_MOLEC_CM2               # molec/cm2
+        obs_col.attrs["units"] = "molecules/cm2"   # granule attr says mol m-2
+
+        # QA filter: obs and model masked together so pixel sets stay aligned
+        if qa_min and "qa_value" in o.variables:
+            qa = o["qa_value"]
+            if float(np.nanmax(np.asarray(qa.values))) > 1.5:
+                qa = qa / 100.0
+            good = qa >= qa_min
+            obs_col = obs_col.where(good)
+            model_col = model_col.where(good)
+
+        swath = xr.Dataset({sp: model_col, obs_var: obs_col,
+             "latitude_bounds": o["latitude_bounds"],
+             "longitude_bounds": o["longitude_bounds"]},
+            coords={"longitude": o["longitude"], "latitude": o["latitude"]},
+        )
+        swath[obs_var].attrs["source_variable"] = src
+
+        _save_present = [v for v in save_vars
+                         if v in o.variables and v not in swath.variables]
+        for v in _save_present:
+            swath[v] = o[v]
+            
+        # per-pixel retrieval error for inverse-variance weighting in 'series'
+        _attach_obs_err(swath, o, obs_var)
+        
+        for t in targets:
+            if t == "swath":
+                # native pixel vector (no gridding); time is a per-pixel coord,
+                # so it concatenates along 'obs', not 'time'.
+                out_by[t].append(_tropomi_swath_pixels(swath, sp, obs_var, gtime,
+                                                        save_vars=_save_present))
+                continue
+                
+            # For gridded targets only carry 2-D per-pixel save vars (AMF, sza,
+            # cloud, qa). keep the full
+            # AK on the 'swath' product instead.
+            _grid_save = [v for v in _save_present if swath[v].ndim <= 2]
+            if not _warned_3d and len(_grid_save) < len(_save_present):
+                _dropped = [v for v in _save_present if swath[v].ndim > 2]
+                print(f"TROPOMI {product}: not regridding layer-resolved save "
+                      f"var(s) {_dropped} to '{t}' (preserved on 'swath' only).",
+                      flush=True)
+                _warned_3d = True
+                
+            on = _swath_to_target(swath, modobj, method, [sp, obs_var] + _grid_save,
+                                  t, obs_grid_res, extent, units=obs_grid_units)
+            
+            if gtime is not None:
+                tval = gtime if np.ndim(gtime) == 0 else np.asarray(gtime).ravel()[0]
+                on = on.expand_dims(time=[np.datetime64(tval)])
+            out_by[t].append(on)
+
+    def _cat(t, lst):
+        if not lst:
+            return xr.Dataset()
+        return xr.concat(lst, dim="obs" if t == "swath" else "time")
+
+    return {t: _cat(t, lst) for t, lst in out_by.items()}
+    
+
+
+    

--- a/melodies_monet/util/sat_l2_swath_utility_tempo.py
+++ b/melodies_monet/util/sat_l2_swath_utility_tempo.py
@@ -8,6 +8,7 @@
 """Python utility for TEMPO use."""
 
 import collections
+import gc
 import glob
 import logging
 import warnings
@@ -17,9 +18,37 @@ import numpy as np
 import xarray as xr
 import xesmf as xe
 
+from melodies_monet.util.tools import calc_partialcolumn
+
 numba_logger = logging.getLogger("numba")
 numba_logger.setLevel(logging.WARNING)
 
+logger = logging.getLogger(__name__)
+
+# Regridding methods valid for unstructured (cell-data) models such as
+# CESM-SE / MUSICA. ESMF 'bilinear' and 'patch' interpolate from mesh
+# NODES, but model output lives on cell centers (faces) -- DO NOT USE. 
+# Conservative (face-to-face, mass-conserving) is recommended;
+# the nearest family is the fast, non-conserving alternative.
+
+_UNSTRUCT_CONSERVATIVE = ("conservative", "conservative_normed")
+_UNSTRUCT_NEAREST = ("nearest_s2d", "nearest_d2s", "radius_mean")
+_UNSTRUCT_SUPPORTED = _UNSTRUCT_CONSERVATIVE + _UNSTRUCT_NEAREST
+
+def _unsupported_method_error(method, where):
+    """ValueError explaining which regrid methods unstructured
+    models support, and why bilinear/patch don't."""
+    return ValueError(
+        f"{where}: regrid_method={method!r} is not supported for unstructured "
+        "(cell-data) models such as CESM-SE / MUSICA.\n"
+        "ESMF 'bilinear' and 'patch' interpolate from mesh NODES, but the "
+        "model output is on cell centers (faces), so those methods cannot be "
+        "applied.\n"
+        "Supported methods (set 'regrid_method:' in the obs YAML block):\n"
+        "  - 'conservative'  (RECOMMENDED) true area-weighted, mass-conserving\n"
+        "  - 'nearest_s2d' / 'nearest_d2s'  fast nearest-neighbor (not conserving)\n"
+        "  - 'radius_mean'  within-radius average (swath->model direction)"
+    )
 
 def calc_grid_corners(ds, lat="latitude", lon="longitude"):
     """Adds latitude and longitude bounds inplace.
@@ -48,27 +77,162 @@ def calc_grid_corners(ds, lat="latitude", lon="longitude"):
     ds["lon_b"] = cfxr.bounds_to_vertices(corners[f"{lon}_bounds"], "bounds", order=None)
     return
 
+def _nearest_mod2swath(modobj, obsobj):
+    """Sample an unstructured model at swath pixel locations.
 
-def speedup_regridding(dset, variables="all"):
-    """Makes modobj latitude and longitude C_contiguous, which speeds up regridding.
-    It makes the changes inplace
-
-    Parameters
-    ----------
-    dset : xr.Dataset
-        Dataset containing latitude and longitude
-
-    Returns
-    -------
-    None
+    Thin wrapper around :func:`melodies_monet.util.regrid.regrid` for the
+    forward (model -> swath) direction: the 2-D swath ``(x, y)`` lon/lat
+    are the targets, and the model column centers are the cKDTree source.
+    Downstream swath code (vertical interp, apply weights) expects
+    ``lon``/``lat`` (short names) on ``(x, y)``, so we rename the
+    long-name coords ``regrid`` attaches back to the swath convention.
+    
     """
-    if variables == "all":
-        variables = dset.variables
-    for v in variables:
-        if not dset[v].values.flags["C_CONTIGUOUS"]:
-            dtype = dset[v].dtype
-            dset[v] = dset[v].astype(dtype, order="C")
+    from melodies_monet.util.regrid_util import regrid
 
+    out = regrid(
+        modobj,
+        target={
+            "lon": np.asarray(obsobj["lon"].values),
+            "lat": np.asarray(obsobj["lat"].values),
+        },
+        method="nearest_s2d",
+        target_dims=("x", "y"),
+    )
+
+    return out.rename({"longitude": "lon", "latitude": "lat"})
+
+def _swath_corner_bounds(obsobj):
+    """Return (lon_bounds, lat_bounds) DataArrays for a TEMPO swath.
+
+    Handles the naming variants: TEMPO V03 ``latitude_bounds`` /
+    ``longitude_bounds``, generic ``lat_bounds`` / ``lon_bounds``, or the
+    ``calc_grid_corners`` output ``lat_b`` / ``lon_b``.
+    """
+    for lon_n, lat_n in (
+        ("longitude_bounds", "latitude_bounds"),
+        ("lon_bounds", "lat_bounds"),
+        ("lon_b", "lat_b"),
+    ):
+        if lon_n in obsobj.variables and lat_n in obsobj.variables:
+            return obsobj[lon_n], obsobj[lat_n]
+    return None, None
+
+def _carry_swath_bounds(output, obs_src):
+    """Merge swath corner bounds from ``obs_src`` into ``output`` if present.
+
+    Lets the backward (swath -> model) conservative path rebuild the swath
+    mesh later: the paired output otherwise drops the bounds.
+    """
+    lon_b, lat_b = _swath_corner_bounds(obs_src)
+    if lon_b is None:
+        return output
+    extra = xr.Dataset({lon_b.name: lon_b, lat_b.name: lat_b})
+    return xr.merge([output, extra], compat="override")
+
+
+def _conservative_mod2swath(modobj, obsobj, method="conservative"):
+    """Conservatively regrid an unstructured model onto a TEMPO swath.
+
+    Builds a uxarray Grid from the swath pixel corner bounds
+    (``longitude_bounds``/``latitude_bounds``, shape ``(x, y, corner)``),
+    then uses xregrid mesh-to-mesh conservative regridding from the model's
+    (depadded SCRIP) mesh onto the swath cells. Result is reshaped back to
+    the swath ``(..., x, y)`` layout with ``lon``/``lat`` coords, matching
+    the convention downstream vertical-interp / apply-weights code expects.
+    """
+    from melodies_monet.util.regrid_util import regrid
+    from melodies_monet.util.uxarray_util import (
+        faces_to_grid, subset_model_source, uxgrid_from_corner_bounds)
+
+    lon_b, lat_b = _swath_corner_bounds(obsobj)
+    if lon_b is None:
+        raise ValueError(
+            "_conservative_mod2swath: swath has no corner bounds "
+            "(latitude_bounds/longitude_bounds). Conservative regridding "
+            f"needs them. Available: {list(obsobj.variables)}."
+        )
+
+    olon = np.asarray(obsobj["lon"].values)
+    olat = np.asarray(obsobj["lat"].values)
+    nx, ny = olon.shape
+
+    # Flatten (x, y, corner) -> (x*y, corner) in C order; the n_face order of
+    # the resulting mesh is row-major over (x, y), so reshape back the same way.
+    clon = np.asarray(lon_b.values).reshape(nx * ny, -1)
+    clat = np.asarray(lat_b.values).reshape(nx * ny, -1)
+    swath_grid = uxgrid_from_corner_bounds(clon, clat)
+
+     # model grid file (e.g. SCRIP) or the native MPAS mesh
+    grid_file = (modobj.attrs.get("mio_scrip_file")
+                 or modobj.attrs.get("mio_mesh_file"))
+
+    src, src_grid = subset_model_source(
+        modobj, grid_file,
+        float(np.nanmin(clon)), float(np.nanmax(clon)),
+        float(np.nanmin(clat)), float(np.nanmax(clat)),
+        label="_conservative_mod2swath",
+    )
+    out = regrid(src, method=method, src_grid=src_grid, target_grid=swath_grid)
+    
+    result = faces_to_grid(out, (nx, ny), ("x", "y"))
+    result.attrs = dict(modobj.attrs)
+    return result.assign_coords(
+        lon=(("x", "y"), olon),
+        lat=(("x", "y"), olat),
+    )
+
+def _unstructured_back_to_modgrid(
+    concatenated, modobj, method="radius_mean", radius_deg=0.1,):
+    
+    """Project swath-paired data onto an unstructured model's columns.
+    Two modes:
+
+    - ``method`` in (conservative, bilinear, ...) and swath corner bounds
+      are present -> true area-weighted mesh-to-mesh regrid via xregrid
+      (:func:`_conservative_swath2mod`). **Mass-conserving.**
+    - otherwise -> cKDTree within-radius mean: each model column gets the
+      mean of all swath pixels within ``radius_deg`` (poor-man's area
+      weighting; columns with no pixel in range -> NaN). 0.1 deg ~= ~10 km.
+    """
+    from melodies_monet.util.regrid_util import regrid
+
+    if method in _UNSTRUCT_CONSERVATIVE:
+        lon_b, _ = _swath_corner_bounds(concatenated)
+        if lon_b is not None:
+            return _conservative_swath2mod_scan([concatenated], modobj, method=method)
+        warnings.warn(
+            "_unstructured_back_to_modgrid: conservative requested but the "
+            "paired swath has no corner bounds; falling back to radius_mean. "
+            "(Bounds are carried by _carry_swath_bounds in "
+            "regrid_and_apply_weights -- check they survived.)"
+        )
+    elif method not in _UNSTRUCT_NEAREST:
+        # bilinear / patch / anything else hard error with guidance.
+        raise _unsupported_method_error(method, "_unstructured_back_to_modgrid")
+
+    # Flatten swath (x, y) -> 1-D "pixel" with longitude/latitude as coords
+    # so regrid() sees it as an unstructured source.
+    flat = (
+        concatenated
+        .stack(pixel=("x", "y"))
+        .reset_index("pixel", drop=True)
+    )
+    if "lon" in flat.variables and "longitude" not in flat.variables:
+        flat = flat.rename({"lon": "longitude", "lat": "latitude"})
+    flat = flat.set_coords(["longitude", "latitude"])
+
+    mlon = np.asarray(modobj["longitude"].values).ravel()
+    mlat = np.asarray(modobj["latitude"].values).ravel()
+    col_dim = modobj["longitude"].dims[0]
+
+    return regrid(
+        flat,
+        target={"lon": mlon, "lat": mlat},
+        method="radius_mean",
+        radius=radius_deg,
+        target_dims=(col_dim,),
+    )
 
 def tempo_interp_mod2swath(obsobj, modobj, method="conservative", weights=None):
     """Interpolate model to satellite swath/swaths
@@ -94,6 +258,18 @@ def tempo_interp_mod2swath(obsobj, modobj, method="conservative", weights=None):
     """
 
     mod_at_swathtime = modobj.interp(time=obsobj.time.mean())
+
+    if mod_at_swathtime.attrs.get("mio_has_unstructured_grid", False):
+        # Unstructured model. conservative and true area-weighted mesh-to-mesh
+        # via xregrid (mass-conserving). nearest goes via fast cKDTree. bilinear/
+        # patch are NOT supported (ESMF needs node-located data).
+        if method in _UNSTRUCT_CONSERVATIVE:
+            return _conservative_mod2swath(mod_at_swathtime, obsobj, method=method)
+        
+        if method in _UNSTRUCT_NEAREST:
+            return _nearest_mod2swath(mod_at_swathtime, obsobj)
+        raise _unsupported_method_error(method, "tempo_interp_mod2swath")
+                    
     if weights is None:
         regridder = xe.Regridder(
             mod_at_swathtime,
@@ -289,179 +465,146 @@ def interp_vertical_mod2swath(obsobj, modobj, variables="NO2_col"):
     modsatlayers["pres_pa_mid"].attrs["description"] = _interp_description
     return modsatlayers
 
+def _apply_scattering_weights(obsobj, modobj, species, amf_var, tropospheric):
+    """Core AK operator shared by the TEMPO NO2/HCHO variants.
 
-def calc_partialcolumn(modobj, var="NO2"):
-    """Calculates the partial column of a species from its concentration.
+    Computes ``sum_l(SW_l * partial_col_l) / AMF`` on the retrieval layers.
+    For tropospheric products the scattering weights are masked above the
+    retrieval tropopause (reported in hPa; model pressures are Pa) so the
+    stratosphere does not enter the sum.
 
     Parameters
     ----------
+    obsobj : xr.Dataset
+        TTEMPO data, including scattering weights and the AMF.
     modobj : xr.Dataset
-        Model data
-    var : str
-        variable to calculate the partial column from
+        Model data on TEMPO layers, with ``{species}_col`` partial columns.
+    species : str
+        Model species name (e.g. "NO2", "CH2O").
+    amf_var : str
+        Name of the AMF variable in ``obsobj`` ("amf_troposphere" or "amf").
+    tropospheric : bool
+        If True, mask above ``tropopause_pressure`` before summing.
 
     Returns
     -------
     xr.DataArray
-        DataArray containing the partial column of the species.
+        Model column after applying scattering weights and AMF (molec/cm2).
     """
-    R = 8.314  # m3 * Pa / K / mol
-    NA = 6.022e23
-    ppbv2molmol = 1e-9
-    m2_to_cm2 = 1e4
-    fac_units = ppbv2molmol * NA / m2_to_cm2
-    partial_col = (
-        modobj[var]
-        * modobj["pres_pa_mid"]
-        * modobj["dz_m"]
-        * fac_units
-        / (R * modobj["temperature_k"])
+    
+    partial_col = modobj[f"{species}_col"]
+    scattering_weights = (
+        obsobj["scattering_weights"]
+        .transpose("swt_level", "x", "y")
+        .rename({"swt_level": "z"})
     )
-    return partial_col
+    if tropospheric:
+        tropopause_pa = obsobj["tropopause_pressure"] * 100  # hPa -> Pa
+        scattering_weights = scattering_weights.where(
+            modobj["pres_pa_mid"] >= tropopause_pa)
+    amf = obsobj[amf_var]
+    col = (scattering_weights * partial_col).sum(dim="z") / amf
+    col = col.where(partial_col.isel(z=0).notnull())
 
+    # AK sanity diagnostic (enable with logging DEBUG): the AK-applied/raw
+    # ratio equals AMF_model/AMF_retrieval. This helped exposed
+    # the xregrid conservative doubling; keep it cheap and available.
+    if logger.isEnabledFor(logging.DEBUG):
+        try:
+            raw = partial_col.where(scattering_weights.notnull()).sum(dim="z")
+            ratio = (col / raw).where(raw != 0)
+            logger.debug(
+                "[AK] TEMPO %s: raw_col=%.2e AK-applied=%.2e AK/raw=%.2f "
+                "(=AMF_mod/AMF_ret)", species,
+                float(np.nanmean(raw.values)), float(np.nanmean(col.values)),
+                float(np.nanmean(ratio.values)))
+        except Exception as e:  # noqa: BLE001
+            logger.debug("[AK] TEMPO %s ratio diag skipped: %r", species, e)
+
+    col.attrs = {
+        "units": "molecules/cm2",
+        "description": (f"model {species} "
+                        f"{'tropospheric ' if tropospheric else ''}column "
+                        "after applying TEMPO scattering weights and AMF"),
+        "history": "Created by MELODIES-MONET, _apply_scattering_weights, TEMPO util",
+    }
+    return col.where(np.isfinite(col))
+
+
+def _apply_scattering_weights_hydrostatic(obsobj, modobj, species, amf_var,
+                                          tropospheric):
+    """Hydrostatic variant of :func:`_apply_scattering_weights`.
+
+    Used when the model provides no ``dz_m``: the partial column is built
+    from the retrieval layer pressure thickness (``dp * VMR * NA/g``,
+    Cooper et al. 2020, doi:10.5194/acp-20-7231-2020) instead of the
+    model's geometric thickness and temperature.
+    
+    """
+    unit_c = 6.022e23 * 9.8 / 1e4 * 1e-9  # NA * g / m2_to_cm2 * ppbv2molmol
+    dp = _calc_dp(obsobj).rename({"swt_level": "z"})
+    scattering_weights = (
+        obsobj["scattering_weights"]
+        .transpose("swt_level", "x", "y")
+        .rename({"swt_level": "z"})
+    )
+    mod = modobj[species]
+    if tropospheric:
+        tropopause_pa = obsobj["tropopause_pressure"] * 100  # hPa -> Pa
+        scattering_weights = scattering_weights.where(
+            modobj["pres_pa_mid"] >= tropopause_pa)
+        mod = mod.where(modobj["pres_pa_mid"] >= tropopause_pa)
+    col = (dp * scattering_weights * mod).sum(dim="z") * unit_c / obsobj[amf_var]
+    col = col.where(mod.isel(z=0).notnull())
+    col.attrs = {
+        "units": "molecules/cm2",
+        "description": (f"model {species} "
+                        f"{'tropospheric ' if tropospheric else ''}column "
+                        "after applying TEMPO scattering weights and AMF "
+                        "(hydrostatic)"),
+        "history": ("Created by MELODIES-MONET, "
+                    "_apply_scattering_weights_hydrostatic, TEMPO util"),
+    }
+    return col.where(np.isfinite(col))
+
+
+def apply_weights_mod2tempo_no2(obsobj, modobj, species="NO2",
+                                column_type="tropospheric"):
+    """TEMPO NO2 AK operator (tropospheric column).
+
+    See :func:`_apply_scattering_weights` for the calculation.
+    """
+    if column_type != "tropospheric":
+        raise NotImplementedError(
+            "apply_weights_mod2tempo_no2: only column_type='tropospheric' "
+            "is implemented for TEMPO NO2.")
+    return _apply_scattering_weights(
+        obsobj, modobj, species, "amf_troposphere", tropospheric=True)
 
 def apply_weights_mod2tempo_no2_hydrostatic(obsobj, modobj, species="NO2"):
-    """Apply the scattering weights and air mass factors according to
-    Cooper et. al, 2020, doi: https://doi.org/10.5194/acp-20-7231-2020,
-    assuming the hydrostatic equation. It does not require temperature
-    nor geometric layer thickness.
+    """TEMPO NO2 AK operator, hydrostatic fallback (no ``dz_m``).
 
-    Parameters
-    ----------
-    obsobj : xr.Dataset
-        TEMPO data, including pressure and scattering weights
-    modobj : xr.Dataset
-        Model data, already interpolated to TEMPO grid
-
-    Returns
-    -------
-    xr.DataArray
-        A xr.DataArray containing the NO2 model data after applying
-        the air mass factors and scattering weights
+    See :func:`_apply_scattering_weights_hydrostatic`.
     """
-    unit_c = 6.022e23 * 9.8 / 1e4  # NA * g / m2_to_cm2
-    dp = _calc_dp(obsobj).rename({"swt_level": "z"})
-    ppbv2molmol = 1e-9
-    tropopause_pressure = obsobj["tropopause_pressure"]
-    scattering_weights = obsobj["scattering_weights"].transpose("swt_level", "x", "y")
-    scattering_weights = scattering_weights.rename({"swt_level": "z"})
-    scattering_weights = scattering_weights.where(modobj["pres_pa_mid"] >= tropopause_pressure)
-    modno2 = modobj[species].where(modobj["pres_pa_mid"] >= tropopause_pressure)
-    amf_troposphere = obsobj["amf_troposphere"]
-    modno2col_trfmd = (dp * scattering_weights * modno2).sum(dim="z") * unit_c * ppbv2molmol
-    modno2col_trfmd = modno2col_trfmd.where(modno2.isel(z=0).notnull())
-    modno2col_trfmd = modno2col_trfmd / amf_troposphere
-    modno2col_trfmd.attrs = {
-        "units": "molecules/cm2",
-        "description": "model NO2 tropospheric column after applying TEMPO scattering weights and AMF",
-        "history": "Created by MELODIES-MONET, apply_weights_mod2tempo_no2_hydrostatic, TEMPO util",
-    }
-    return modno2col_trfmd.where(np.isfinite(modno2col_trfmd))
-
-
-def apply_weights_mod2tempo_no2(obsobj, modobj, species="NO2", column_type="tropospheric"):
-    """Apply the scattering weights and air mass factors according to
-    Cooper et. al, 2020, doi: https://doi.org/10.5194/acp-20-7231-2020
-
-    Parameters
-    ----------
-    obsobj : xr.Dataset
-        TEMPO data, including pressure and scattering weights
-    modobj : xr.Dataset
-        Model data, already interpolated to TEMPO grid
-    column_type : str
-        Whether the "tropospheric" or "total" column should be used for the calculation
-
-    Returns
-    -------
-    xr.DataArray
-        A xr.DataArray containing the NO2 model data after applying
-        the air mass factors and scattering weights
-    """
-    partial_col = modobj[f"{species}_col"]
-
-    scattering_weights = obsobj["scattering_weights"].transpose("swt_level", "x", "y")
-    scattering_weights = scattering_weights.rename({"swt_level": "z"})
-    if column_type == "tropospheric":
-        tropopause_pressure = obsobj["tropopause_pressure"] * 100
-        scattering_weights = scattering_weights.where(modobj["pres_pa_mid"] >= tropopause_pressure)
-        amf_troposphere = obsobj["amf_troposphere"]
-    modno2col_trfmd = (scattering_weights * partial_col).sum(dim="z") / amf_troposphere
-    modno2col_trfmd = modno2col_trfmd.where(modobj[f"{species}_col"].isel(z=0).notnull())
-    modno2col_trfmd.attrs = {
-        "units": "molecules/cm2",
-        "description": "model NO2 tropospheric column after applying TEMPO scattering weights and AMF",
-        "history": "Created by MELODIES-MONET, apply_weights_mod2tempo_no2, TEMPO util",
-    }
-    return modno2col_trfmd.where(np.isfinite(modno2col_trfmd))
-
-
-def apply_weights_mod2tempo_hcho_hydrostatic(obsobj, modobj, species="HCHO"):
-    """Apply the scattering weights and air mass factors according to
-    Cooper et. al, 2020, doi: https://doi.org/10.5194/acp-20-7231-2020,
-    assuming the hydrostatic equation. It does not require temperature
-    nor geometric layer thickness.
-
-    Parameters
-    ----------
-    obsobj : xr.Dataset
-        TEMPO data, including pressure and scattering weights
-    modobj : xr.Dataset
-        Model data, already interpolated to TEMPO grid
-
-    Returns
-    -------
-    xr.DataArray
-        A xr.DataArray containing the NO2 model data after applying
-        the air mass factors and scattering weights
-    """
-    unit_c = 6.022e23 * 9.8 / 1e4  # NA * g / m2_to_cm2
-    dp = _calc_dp(obsobj).rename({"swt_level": "z"})
-    ppbv2molmol = 1e-9
-    scattering_weights = obsobj["scattering_weights"].transpose("swt_level", "x", "y")
-    scattering_weights = scattering_weights.rename({"swt_level": "z"})
-    modhcho = modobj[species]
-    amf = obsobj["amf"]
-    modhcho_col = (dp * scattering_weights * modhcho).sum(dim="z") * unit_c * ppbv2molmol
-    modhcho_col = modhcho_col / amf
-    modhcho_col.attrs = {
-        "units": "molecules/cm2",
-        "description": "model HCHO column after applying TEMPO scattering weights and AMF",
-        "history": "Created by MELODIES-MONET, apply_weights_mod2tempo_hcho_hydrostatic, TEMPO util",
-    }
-    return modhcho_col.where(np.isfinite(modhcho_col))
+    return _apply_scattering_weights_hydrostatic(
+        obsobj, modobj, species, "amf_troposphere", tropospheric=True)
 
 
 def apply_weights_mod2tempo_hcho(obsobj, modobj, species="HCHO"):
-    """Apply the scattering weights and air mass factors according to
-    Cooper et. al, 2020, doi: https://doi.org/10.5194/acp-20-7231-2020
-
-    Parameters
-    ----------
-    obsobj : xr.Dataset
-        TEMPO data, including pressure and scattering weights
-    modobj : xr.Dataset
-        Model data, already interpolated to TEMPO grid
-
-    Returns
-    -------
-    xr.DataArray
-        A xr.DataArray containing the NO2 model data after applying
-        the air mass factors and scattering weights
+    """TEMPO HCHO AK operator (total column).
+    
+    See :func:`_apply_scattering_weights` for the calculation.
     """
-    partial_col = modobj[f"{species}_col"]
+    return _apply_scattering_weights(
+        obsobj, modobj, species, "amf", tropospheric=False)
 
-    scattering_weights = obsobj["scattering_weights"].transpose("swt_level", "x", "y")
-    scattering_weights = scattering_weights.rename({"swt_level": "z"})
-    amf = obsobj["amf"]
-    modhcho_col = (scattering_weights * partial_col).sum(dim="z") / amf
-    modhcho_col = modhcho_col.where(modobj[f"{species}_col"].isel(z=0).notnull())
-    modhcho_col.attrs = {
-        "units": "molecules/cm2",
-        "description": "model HCHO column after applying TEMPO scattering weights and AMF",
-        "history": "Created by MELODIES-MONET, apply_weights_mod2tempo_hcho, TEMPO util",
-    }
-    return modhcho_col.where(np.isfinite(modhcho_col))
+def apply_weights_mod2tempo_hcho_hydrostatic(obsobj, modobj, species="HCHO"):
+    """TEMPO HCHO AK operator, hydrostatic fallback (no ``dz_m``).
+
+    See :func:`_apply_scattering_weights_hydrostatic`.
+    """
+    return _apply_scattering_weights_hydrostatic(
+        obsobj, modobj, species, "amf", tropospheric=False)
 
 
 def is_nonpairable(obsobj, k, modobj):
@@ -478,21 +621,27 @@ def is_nonpairable(obsobj, k, modobj):
 
     Return
     ------
-    collections.OrderedDict[str, xr.Dataset]
+    bool
+        True when the granule's bbox has no overlap with the model domain.
     """
-    if obsobj[k]["lon"].max() < modobj["longitude"].min():
+    from melodies_monet.util.uxarray_util import to_neg180
+    
+    # Normalize longitudes to the same [-180, 180] convention before
+    # comparing: a 0..360 model and a -180..180 swath otherwise look
+    # disjoint and every granule gets discarded.
+    mlon = to_neg180(modobj["longitude"].values)
+    olon = to_neg180(obsobj[k]["lon"].values)
+    
+    if olon.max() < mlon.min() or olon.min() > mlon.max():
         return True
-    elif obsobj[k]["lon"].min() > modobj["longitude"].max():
-        return True
-    elif obsobj[k]["lat"].max() < modobj["latitude"].min():
-        return True
-    elif obsobj[k]["lat"].min() > modobj["latitude"].max():
+    if (obsobj[k]["lat"].max() < modobj["latitude"].min() or obsobj[k]["lat"].min() > modobj["latitude"].max()):
         return True
     return False
 
 
 def _regrid_and_apply_weights(
-    obsobj, modobj, method="conservative", weights=None, species=["NO2"], tempo_sp="NO2"
+    obsobj, modobj, method="conservative", weights=None, species=["NO2"], tempo_sp="NO2",
+    crop_extent=None,
 ):
     """Does the complete process of regridding and
     applying scattering weights. Assumes that obsobj is a Dataset
@@ -524,7 +673,9 @@ def _regrid_and_apply_weights(
         assert tempo_sp == "HCHO", "TEMPO species must be HCHO or NO2."
         apply_weights = apply_weights_mod2tempo_hcho
         apply_weights_hydrostatic = apply_weights_mod2tempo_hcho_hydrostatic
-    if method == "conservative":
+    if method == "conservative" and not modobj.attrs.get(
+        "mio_has_unstructured_grid", False
+    ):
         if "lat_b" not in modobj:
             calc_grid_corners(modobj)
         if "lat_b" not in obsobj:
@@ -537,6 +688,31 @@ def _regrid_and_apply_weights(
         )
         modobj_swath["dz_m"] = calc_dz_m_from_altitude(modobj_swath["altitude"])
         modobj_swath[f"{species[0]}_col"] = calc_partialcolumn(modobj_swath, var=species[0])
+
+        # Column-conservation diagnostic (enable with logging DEBUG): the
+        # tropospheric column on NATIVE model levels vs after interp to TEMPO
+
+        # levels must match (~1); a big departure = the interp misplaces mass.
+        if logger.isEnabledFor(logging.DEBUG):
+            try:
+                sp = species[0]
+                pc_nat = calc_partialcolumn(modobj_hs, var=sp)
+                if "tropopause_pressure" in obsobj:
+                    tp = obsobj["tropopause_pressure"] * 100  # hPa -> Pa
+                else:
+                    tp = 0.0 * modobj_hs["pres_pa_mid"].isel(z=0)  # full column
+                cn = pc_nat.where(modobj_hs["pres_pa_mid"] >= tp).sum("z")
+                ci = (modobj_swath[f"{sp}_col"]
+                      .where(modobj_swath["pres_pa_mid"] >= tp).sum("z"))
+                cr = (ci / cn).where(cn != 0)
+                logger.debug(
+                    "[AK-cons] %s trop col native=%.2e interp=%.2e "
+                    "interp/native mean=%.2f (expect ~1)", sp,
+                    float(np.nanmean(cn.values)), float(np.nanmean(ci.values)),
+                    float(np.nanmean(cr.values)))
+            except Exception as e:  # noqa: BLE001
+                logger.debug("[AK-cons] skipped: %r", e)
+                
         da_out = apply_weights(obsobj, modobj_swath, species=f"{species[0]}")
     else:
         warnings.warn(
@@ -557,6 +733,8 @@ def regrid_and_apply_weights(
     weights=None,
     species=["NO2"],
     tempo_sp="NO2",
+    crop_extent=None,
+    save_vars = None,
 ):
     """Does the complete process of regridding
     and applying scattering weights.
@@ -595,58 +773,192 @@ def regrid_and_apply_weights(
         assert tempo_sp == "HCHO", "TEMPO species must be HCHO or NO2."
         sat_species_name = "vertical_column"
 
+    def _obs_pair_vars(src):
+        """Obs column + any per-pixel retrieval uncertainty/precision that goes
+        with it. Carrying the error forward lets 'series' inverse-variance
+        weight (instead of silently falling back to area) and lets 'swath'
+        preserve per-pixel uncertainty. 
+        """
+        names = [sat_species_name]
+        for v in src.variables:
+            if v == sat_species_name:
+                continue
+            if v.startswith(sat_species_name) and v.endswith(("_uncertainty", "_precision")):
+                names.append(v)
+        # extra obs vars flagged save:True in the control (closure over save_vars)
+        for v in (save_vars or []):
+            if v in src.variables and v not in names:
+                names.append(v)
+        return src[names]
+        
+    def _finalize_paired_granule(regridded, granule, ref_time=None):
+        """Wrap one regridded granule as a paired Dataset: attach the granule
+        attrs, merge the obs column (+uncertainty) when pairing, restore the
+        long lat/lon names, and carry the pixel corner bounds forward."""
+        out = regridded.to_dataset(name=species[0])
+        out.attrs["reference_time_string"] = (
+            ref_time if ref_time is not None
+            else granule.attrs["reference_time_string"])
+        out.attrs["final_time_string"] = granule["time"][-1].values.astype(str)
+        out.attrs["scan_num"] = granule.attrs["scan_num"]
+        out.attrs["granule_number"] = granule.attrs["granule_number"]
+        if pair:
+            out = xr.merge([out, _obs_pair_vars(granule)])
+        if "lat" in out.variables:
+            out = out.rename({"lat": "latitude", "lon": "longitude"})
+        return _carry_swath_bounds(out, granule)
+        
+    # crop granule to region of interest
+    from melodies_monet.util.sat_l2_swath_utility import _crop_swath_to_extent
+    
     if isinstance(obsobj, xr.Dataset):
+        if crop_extent is not None:
+            obsobj = _crop_swath_to_extent(obsobj, crop_extent)
+            if obsobj is None:
+                return None
+                
         regridded = _regrid_and_apply_weights(
             obsobj, modobj, method=method, weights=weights, species=species, tempo_sp=tempo_sp
         )
-        output = regridded.to_dataset(name=species[0])
-        output.attrs["reference_time_string"] = obsobj.attrs["reference_time_string"]
-        output.attrs["final_time_string"] = obsobj["time"][-1].values.astype(str)
-        output.attrs["scan_num"] = obsobj.attrs["scan_num"]
-        output.attrs["granule_number"] = obsobj.attrs["granule_number"]
-        if pair:
-            output = xr.merge([output, obsobj[sat_species_name]])
-        if "lat" in output.variables:
-            output = output.rename({"lat": "latitude", "lon": "longitude"})
-        return output
+        return _finalize_paired_granule(regridded, obsobj)
     if isinstance(obsobj, dict):
         output_multiple = {}
         for ref_time in obsobj.keys():
             if is_nonpairable(obsobj, ref_time, modobj):
                 warnings.warn(f"{ref_time} granule domain has no overlap with model. Discarding.")
                 continue
+                
+            granule = obsobj[ref_time]
+            if crop_extent is not None:
+                _pre = dict(granule.sizes)
+                granule = _crop_swath_to_extent(granule, crop_extent)
+                if granule is None:
+                    if verbose:
+                        print(f"  {ref_time}: no overlap with crop_extent="
+                              f"{crop_extent}; granule discarded", flush=True)
+                    continue
+                if verbose:
+                    print(f"  {ref_time}: cropped {_pre} -> "
+                          f"{dict(granule.sizes)}", flush=True)
+            elif verbose:
+                print(f"  {ref_time}: crop_extent is None; granule NOT cropped",
+                      flush=True)
             if verbose:
                 print(f"Regridding {ref_time} and applying AMF and weights")
-            output_multiple[ref_time] = _regrid_and_apply_weights(
-                obsobj[ref_time],
+            regridded = _regrid_and_apply_weights(
+                granule,
                 modobj,
                 method=method,
                 weights=weights,
                 species=species,
                 tempo_sp=tempo_sp,
-            ).to_dataset(name=species[0])
-            output_multiple[ref_time].attrs["reference_time_string"] = ref_time
-            output_multiple[ref_time].attrs["scan_num"] = obsobj[ref_time].attrs["scan_num"]
-            output_multiple[ref_time].attrs["granule_number"] = obsobj[ref_time].attrs[
-                "granule_number"
-            ]
-            output_multiple[ref_time].attrs["final_time_string"] = obsobj[ref_time]["time"][
-                -1
-            ].values.astype(str)
-            if pair:
-                output_multiple[ref_time] = xr.merge(
-                    [
-                        output_multiple[ref_time],
-                        obsobj[ref_time][sat_species_name],
-                    ]
-                )
-            if "lat" in output_multiple[ref_time].variables:
-                output_multiple[ref_time] = output_multiple[ref_time].rename(
-                    {"lat": "latitude", "lon": "longitude"}
-                )
+            )
+
+            # load + collect per granule to keep the peak footprint at
+            # one-granule scale instead of accumulating lazy graphs.
+            output_multiple[ref_time] = _finalize_paired_granule(
+                regridded, granule, ref_time=ref_time
+            ).load()
+            gc.collect()
+
         return output_multiple
     raise TypeError("Obsobj must be xr.Dataset or dict")
 
+def _conservative_swath2mod_scan(granules, modobj, method="conservative"):
+    """Conservative swath to unstructured-mesh regrid, accumulated PER GRANULE.
+
+    Regridding a whole scan at once builds a (huge swath mesh x full model
+    mesh) weight matrix that OOMs
+    
+    Regrid each granule separately against a model-mesh SUBSET (the granule's bbox) and coverage-accumulate
+    the NON-normalized conservative outputs onto the full mesh::
+
+        combined_mean = sum_g(raw_g) / sum_g(cov_g)
+
+    where ``raw_g`` is the (destarea) regrid of the field for granule g and
+    ``cov_g`` is the regrid of ones (fraction of each model cell covered by
+    that granule). Both source (one granule) and target (a strip) stay small,
+    so it scales to the full ne0CONUS mesh without OOM. Uncovered cells
+    (sum cov ~ 0) become NaN.
+    
+    """
+    import uxarray as ux
+    from melodies_monet.util.regrid_util import regrid
+    from melodies_monet.util.uxarray_util import (
+        flatten_to_faces, open_uxgrid, subset_mesh_to_bbox,
+        uxgrid_from_corner_bounds)
+
+    _grid_file = (modobj.attrs.get("mio_scrip_file")
+                  or modobj.attrs.get("mio_mesh_file"))
+    model_grid = open_uxgrid(_grid_file)
+    n_col_full = int(model_grid.n_face)
+
+    num = {}                                       # var full-mesh numerator
+    attrs_by_var = {}
+    den = np.zeros(n_col_full, dtype="float64")    # coverage accumulator
+
+    for g in granules:
+        lon_b, lat_b = _swath_corner_bounds(g)
+        if lon_b is None:
+            continue
+        olon = np.asarray(g["longitude"].values if "longitude" in g.variables
+                          else g["lon"].values)
+        nx, ny = olon.shape
+        clon = np.asarray(lon_b.values).reshape(nx * ny, -1)
+        clat = np.asarray(lat_b.values).reshape(nx * ny, -1)
+        swath_grid = uxgrid_from_corner_bounds(clon, clat)
+
+        flat = flatten_to_faces(
+            g, ("x", "y"),
+            drop=(lon_b.name, lat_b.name, "longitude", "latitude", "lon", "lat"))
+        
+        flat = flat.assign(
+            _mm_cov=(("n_face",), np.ones(flat.sizes["n_face"], dtype="float64")))
+        src_uxds = ux.UxDataset(flat, uxgrid=swath_grid)
+
+        # target subset = model faces in this granule's bbox
+        _keep, tgt = subset_mesh_to_bbox(
+            _grid_file,
+            float(np.nanmin(clon)), float(np.nanmax(clon)),
+            float(np.nanmin(clat)), float(np.nanmax(clat)))
+        if _keep.size == 0:
+            continue
+        if tgt is None:
+            _keep, tgt = np.arange(n_col_full), model_grid
+        out_sub = regrid(src_uxds, method=method, target_grid=tgt)
+        _sfd = next((d for d in out_sub.dims if out_sub.sizes[d] == _keep.size), None)
+        if _sfd is None:
+            continue
+        den[_keep] += np.nan_to_num(
+            np.asarray(out_sub["_mm_cov"].transpose(_sfd).values))
+        for v in out_sub.data_vars:
+            if v == "_mm_cov":
+                continue
+            da = out_sub[v].transpose(..., _sfd)
+            arr = np.nan_to_num(np.asarray(da.values))
+            if v not in num:
+                num[v] = np.zeros(arr.shape[:-1] + (n_col_full,), dtype="float64")
+                attrs_by_var[v] = dict(out_sub[v].attrs)
+            num[v][..., _keep] += arr
+        print(f"_conservative_swath2mod_scan: granule nx*ny={nx * ny} | "
+              f"target {n_col_full} -> {_keep.size} faces", flush=True)
+        del out_sub, src_uxds
+        gc.collect()
+
+    col_dim = modobj["longitude"].dims[0]
+    den_ok = den > 1e-6
+    out = xr.Dataset()
+    for v, arr in num.items():
+        with np.errstate(invalid="ignore", divide="ignore"):
+            mean = arr / den
+        mean = np.where(den_ok, mean, np.nan)
+        extra = tuple(f"_stack{i}" for i in range(arr.ndim - 1))
+        out[v] = xr.DataArray(mean, dims=extra + (col_dim,), attrs=attrs_by_var[v])
+    out = out.assign_coords({
+        "longitude": (col_dim, np.asarray(modobj["longitude"].values).ravel()),
+        "latitude": (col_dim, np.asarray(modobj["latitude"].values).ravel()),
+    })
+    return out
 
 def back_to_modgrid(
     paireddict,
@@ -657,6 +969,10 @@ def back_to_modgrid(
     path="Regridded_object_XYZ.nc",
     method="bilinear",
     grid_path=None,
+    regrid_target="model",
+    obs_grid_res=0.1,
+    obs_grid_units="deg",
+    obs_grid_extent=None,
 ):
     """Grids object in sat-space to modgrid. Designed to grid back to modgrid after applying
     the scattering weights and air mass factors. It is designed for a single scan.
@@ -694,7 +1010,19 @@ def back_to_modgrid(
         ordered_keys = sorted(list(paireddict.keys()))
     else:
         ordered_keys = sorted(list(keys_to_merge))
-    concatenated = paireddict[ordered_keys[0]]
+
+    def _yidx(ds):
+        # Give the across-track dim a positional index so sibling granules of a
+        # scan cropped to DIFFERENT across-track windows can be outer-joined at
+        # concat instead of raising an unindexed-dim size mismatch
+        # Every pixel keeps its own 2-D lon/lat, so per-pixel regrids are unaffected by the
+        # positional alignment; padded cells are NaN and ignored downstream.
+        if "y" in ds.dims and "y" not in ds.indexes:
+            return ds.assign_coords(y=("y", np.arange(ds.sizes["y"])))
+        return ds
+
+    concatenated = _yidx(paireddict[ordered_keys[0]])
+    
     scan_num = concatenated.attrs["scan_num"]
     granules = [concatenated.attrs["granule_number"]]
     ref_times = [concatenated.attrs["reference_time_string"][:-1]]  # Remove unneeded Z
@@ -707,57 +1035,192 @@ def back_to_modgrid(
                     + f"However, {ordered_keys[0]} is from scan {scan_num} and "
                     + f"{k} if from scan {ds_to_add.attrs['scan_num']}."
                 )
-            concatenated = xr.concat([concatenated, paireddict[k]], dim="x")
+            concatenated = xr.concat(
+                [concatenated, _yidx(paireddict[k])], dim="x", join="outer")
             granules.append(paireddict[k].attrs["granule_number"])
             ref_times.append(paireddict[k].attrs["reference_time_string"][:-1])
 
+    # Layer-resolved (3-D) obs vars carried by save_vars (e.g. TEMPO scattering
+    # weights / averaging kernels) are NOT regridded to gridded target. They are also expensive to carry. 
+    # The swaths can keep them 
+    _over2d = [v for v in concatenated.data_vars
+               if concatenated[v].ndim > 2 and "bounds" not in v]
+    if _over2d:
+        print(f"TEMPO: not regridding layer-resolved var(s) {_over2d} to "
+              f"{regrid_target} (preserved on 'swath' only).", flush=True)
+        concatenated = concatenated.drop_vars(_over2d, errors="ignore")
+        paireddict = {k: v.drop_vars([d for d in _over2d if d in v.data_vars],
+                                     errors="ignore")
+                      for k, v in paireddict.items()}
+        
     end_time = np.array(
         paireddict[ordered_keys[-1]].attrs["final_time_string"], dtype="datetime64[ns]"
     )
-    if grid_path is not None:
-        grid = xr.open_dataset(grid_path)
-        regridder = xe.Regridder(concatenated, grid, method=method, unmapped_to_nan=True)
-    else:
-        regridder = xe.Regridder(concatenated, modobj, method=method, unmapped_to_nan=True)
-    out_regridded = regridder(concatenated)
-    for v in out_regridded.variables:
-        if v in concatenated.variables:
-            out_regridded[v].attrs = concatenated[v].attrs
-        else:
-            warnings.warn(f"Variable {v} not found in mod2grid nor obs2grid. Continuing.")
-    out_regridded.attrs["reference_time_string"] = ref_times
-    out_regridded.attrs["granules"] = np.array(granules)
+
+    # enables regridding to obs or model space 
+    targets = [regrid_target] if isinstance(regrid_target, str) else list(regrid_target)
+    
+    from melodies_monet.util.sat_l2_swath_utility import _swath2latlon, _model_lonlat_extent, _swath2series
+    _extent = tuple(obs_grid_extent) if obs_grid_extent else _model_lonlat_extent(modobj)
+    
     scan_num = concatenated.attrs["scan_num"]
-    out_regridded.attrs["scan_num"] = scan_num
-    out_regridded = out_regridded.where(np.isfinite(out_regridded))
-    if add_time:
-        time = [np.array(ref_times[0], dtype="datetime64[ns]")]
-        da_time = xr.DataArray(
-            name="time",
-            data=time,
-            dims=["time"],
-            attrs={"description": "Reference start time of first selected granule in scan."},
-            coords={"time": (("time",), time)},
-        )
-        out_regridded = out_regridded.expand_dims(time=da_time)
-        out_regridded["end_time"] = (("time",), [end_time])
-        out_regridded["end_time"].attrs = {
-            "description": "time at which the last swath of the scan starts"
-        }
-    if to_netcdf:
-        if "XYZ" in path:
-            scan_num = out_regridded.attrs["scan_num"]
-            out_regridded.to_netcdf(
-                path.replace(
-                    "XYZ",
-                    f"S{scan_num:03d}_{out_regridded['time'].values.astype(str)[0][0:19]}",
+
+    results = {}
+    for _tgt in targets:
+        if _tgt == "obs":
+            # Regrid EACH granule onto the fixed lat/lon grid and coverage-mean,
+            # rather than the outer-join-padded scan concat. Keeps each source
+            # small AND avoids NaN-padded corner bounds that would silently knock
+            # conservative down to radius_mean inside _swath2latlon.
+            _acc_sum, _acc_cnt = None, None
+            for _gk in ordered_keys:
+                _g = paireddict[_gk]
+                _gdv = [
+                    v for v in _g.data_vars
+                    if v not in ("lon", "lat", "longitude", "latitude")
+                    and "bounds" not in v
+                ]
+                _one = _swath2latlon(
+                    _g, _gdv, obs_grid_res, _extent,
+                    units=obs_grid_units, method=method,
                 )
-            )
+                _cnt = _one.notnull().astype("float64")
+                _one0 = _one.fillna(0.0)
+                if _acc_sum is None:
+                    _acc_sum, _acc_cnt = _one0, _cnt
+                else:
+                    _acc_sum = _acc_sum + _one0
+                    _acc_cnt = _acc_cnt + _cnt
+            out_regridded = (_acc_sum / _acc_cnt).where(_acc_cnt > 0)
+
+        elif _tgt =="series": # time domain vector 
+            _errs = [v for v in concatenated.data_vars
+                     if v.endswith(("_uncertainty", "_precision"))]
+            _dvars = [
+                v for v in concatenated.data_vars
+                if v not in ("lon", "lat", "longitude", "latitude")
+                and "bounds" not in v and v not in _errs
+            ]
+            _ssw, _obs_var = concatenated, None
+            if _errs:
+                _ssw = concatenated.assign(_obs_err=concatenated[_errs[0]])
+                _base = _errs[0].rsplit("_", 1)[0]
+                _obs_var = _base if _base in _dvars else None
+            out_regridded = _swath2series(_ssw, _dvars, obs_var=_obs_var)
+        elif grid_path is not None:
+            grid = xr.open_dataset(grid_path)
+            regridder = xe.Regridder(concatenated, grid, method=method, unmapped_to_nan=True)
+            out_regridded = regridder(concatenated)
+        elif modobj.attrs.get("mio_has_unstructured_grid", False):
+            # Unstructured target bypass xESMF (memory issues on 1-D ncol targets)
+            # Conservative goes mesh-to-mesh via xregrid; else cKDTree radius-mean.
+            # For conservative, regrid PER GRANULE and coverage-accumulate onto
+            # the full mesh -- concatenating the whole scan first builds a
+            # (huge swath x full mesh) weight matrix that OOMs.
+            if (method in _UNSTRUCT_CONSERVATIVE
+                    and _swath_corner_bounds(concatenated)[0] is not None):
+                out_regridded = _conservative_swath2mod_scan(
+                    [paireddict[k] for k in ordered_keys], modobj, method=method
+                )
+            else:
+                out_regridded = _unstructured_back_to_modgrid(
+                    concatenated, modobj, method=method
+                )
         else:
-            out_regridded.to_netcdf(path)
+            regridder = xe.Regridder(concatenated, modobj, method=method, unmapped_to_nan=True)
+            out_regridded = regridder(concatenated)
 
-    return out_regridded
+        # shared post-processing 
+        for v in out_regridded.variables:
+            if v in concatenated.variables:
+                out_regridded[v].attrs = concatenated[v].attrs
+        out_regridded.attrs["reference_time_string"] = ref_times
+        out_regridded.attrs["granules"] = np.array(granules)
+        out_regridded.attrs["scan_num"] = scan_num
+        out_regridded = out_regridded.where(np.isfinite(out_regridded))
+        if add_time:
+            time = [np.array(ref_times[0], dtype="datetime64[ns]")]
+            da_time = xr.DataArray(
+                name="time",
+                data=time,
+                dims=["time"],
+                attrs={"description": "Reference start time of first selected granule in scan."},
+                coords={"time": (("time",), time)},
+            )
+            out_regridded = out_regridded.expand_dims(time=da_time)
+            out_regridded["end_time"] = (("time",), [end_time])
+            out_regridded["end_time"].attrs = {
+                "description": "time at which the last swath of the scan starts"
+            }
+        if to_netcdf and _tgt == "model":
+            if "XYZ" in path:
+                out_regridded.to_netcdf(
+                    path.replace(
+                        "XYZ",
+                        f"S{scan_num:03d}_{out_regridded['time'].values.astype(str)[0][0:19]}",
+                    )
+                )
+            else:
+                out_regridded.to_netcdf(path)
+        results[_tgt] = out_regridded
+    return results
 
+def _swath_pixels_from_paireddict(paireddict):
+    """Native-swath output: every valid TEMPO pixel across all
+    granules as a 1-D ``obs`` vector, carrying ``longitude``/``latitude``/
+    ``time`` as per-pixel coords. 
+    
+    No regridding onto any imposed grid -- the
+    most faithful product. All-NaN pixels dropped. 
+
+    Only variables that live purely on the swath spatial dims (x, y) are
+    kept, so vertical-level fields and any stray non-spatial dims are skipped.
+    """
+    pieces = []
+    for k in sorted(paireddict):
+        g = paireddict[k]
+        sp = [d for d in ("x", "y") if d in g.dims]
+        if not sp:
+            continue
+        t = np.array(g.attrs["reference_time_string"][:-1], dtype="datetime64[ns]")
+        dvars = [
+            v for v in g.data_vars
+            if "bounds" not in v
+            and v not in ("lon", "lat", "longitude", "latitude")
+            and set(g[v].dims) <= set(sp)
+        ]
+        if not dvars:
+            continue
+        flat = g[dvars].stack(obs=sp).reset_index("obs", drop=True)
+        lon = np.asarray(g["lon"].stack(obs=sp).reset_index("obs", drop=True).values)
+        lat = np.asarray(g["lat"].stack(obs=sp).reset_index("obs", drop=True).values)
+        n = flat.sizes["obs"]
+        flat = flat.assign_coords(
+            longitude=("obs", lon), latitude=("obs", lat),
+            time=("obs", np.full(n, t)),
+        )
+        # carry the pixel CORNER bounds (obs, corner) so the footprint
+        # polygons can be drawn without resampling
+        for _bn in ("longitude_bounds", "latitude_bounds"):
+            if _bn in g.variables:
+                _bb = g[_bn].stack(obs=sp).reset_index("obs", drop=True)
+                _cd = next((d for d in _bb.dims if d != "obs"), None)
+                if _cd is not None:
+                    flat[_bn] = _bb.transpose("obs", _cd)
+                    
+        pieces.append(flat)
+    if not pieces:
+        return xr.Dataset()
+    out = xr.concat(pieces, dim="obs")
+    # drop pixels that are NaN in every data var (outside cropped granule, masked)
+    _sci = [v for v in out.data_vars if "bounds" not in v]
+    keep = np.zeros(out.sizes["obs"], dtype=bool)
+    for v in _sci:
+        keep |= np.isfinite(np.asarray(out[v].values))
+    out = out.isel(obs=np.where(keep)[0])
+    print(f"_swath_pixels_from_paireddict: {out.sizes.get('obs', 0)} valid pixels "
+          f"from {len(paireddict)} granules; vars={list(out.data_vars)}", flush=True)
+    return out
 
 def back_to_modgrid_multiscan(
     paireddict,
@@ -766,6 +1229,10 @@ def back_to_modgrid_multiscan(
     path="Regridded_object_XYZ.nc",
     method="bilinear",
     grid_path=None,
+    regrid_target="model",
+    obs_grid_res=0.1,
+    obs_grid_units="deg",
+    obs_grid_extent=None,
 ):
     """Grids object in sat-space to modgrid. Designed to grid back to modgrid after applying
     the scattering weights and air mass factors. It is designed for multiple scans, and uses
@@ -786,41 +1253,111 @@ def back_to_modgrid_multiscan(
         be ignored.
     method : str
         Method of regridding used by xESMF
-
+    regrid_target: defaults to regridding unstructured grids to model space . If user 
+                   specifies [model, obs] in yaml key argument, then regridding of obs will occur to model and obs space 
+    
     Returns
     -------
     xr.Dataset
         Dataset with obj2grid regridded to modobj.
     """
-    out_regridded = xr.Dataset()
+
+    targets = [regrid_target] if isinstance(regrid_target, str) else list(regrid_target)
+    out_by = {t: xr.Dataset() for t in targets}
+
     ordered_keys = sorted(list(paireddict.keys()))
-    scan_num = paireddict[ordered_keys[0]].attrs["scan_num"]
-    keys_in_scan = [ordered_keys[0]]
-    if len(ordered_keys) > 1:
-        for k in ordered_keys[1:]:
-            if paireddict[k].attrs["scan_num"] == scan_num:
-                keys_in_scan.append(k)
+    if not ordered_keys:
+        raise ValueError(
+            "back_to_modgrid_multiscan received an empty paireddict. "
+            "Every granule was discarded as 'no overlap with model' upstream. "
+            "Check is_nonpairable() and the model/obs longitude conventions "
+            "(model in 0..360 vs obs in -180..180 is a common cause).")
+
+    # "swath" (native pixels) is handled separately -- it is NOT gridded,
+    # so it never enters the back_to_modgrid target loop (which would try to
+    # build a regridder for it). The remaining targets grid as before.
+    grid_targets = [t for t in targets if t != "swath"]
+
+    if grid_targets:
+        _kw = dict(
+            method=method, grid_path=grid_path, regrid_target=grid_targets,
+            obs_grid_res=obs_grid_res, obs_grid_units=obs_grid_units,
+            obs_grid_extent=obs_grid_extent,
+        )
+
+        # Collect one dataset per scan (each carries a unique single-element
+        # 'time'), then concat ONCE along time at the end.
+        per_scan = {t: [] for t in grid_targets}
+
+        def _collect(keys):
+            scan_dict = back_to_modgrid(paireddict, modobj, keys, **_kw)
+            for t in grid_targets:
+                per_scan[t].append(scan_dict[t])
+            del scan_dict
+            gc.collect()
+
+        scan_num = paireddict[ordered_keys[0]].attrs["scan_num"]
+        keys_in_scan = [ordered_keys[0]]
+        if len(ordered_keys) > 1:
+            for k in ordered_keys[1:]:
+                if paireddict[k].attrs["scan_num"] == scan_num:
+                    keys_in_scan.append(k)
+                else:
+                    _collect(keys_in_scan)
+                    scan_num = paireddict[k].attrs["scan_num"]
+                    keys_in_scan = [k]
+        _collect(keys_in_scan)
+        for t in grid_targets:
+            if len(per_scan[t]) == 1:
+                out_by[t] = per_scan[t][0]
             else:
-                regridded_scan = back_to_modgrid(
-                    paireddict, modobj, keys_in_scan, method=method, grid_path=grid_path
-                )
-                out_regridded = xr.merge([out_regridded, regridded_scan])
-                scan_num = paireddict[k].attrs["scan_num"]
-                keys_in_scan = [k]
-    regridded_scan = back_to_modgrid(
-        paireddict, modobj, keys_in_scan, add_time=True, method=method, grid_path=grid_path
-    )
-    out_regridded = xr.merge([out_regridded, regridded_scan])
+                # scans have distinct times -> merge across scans == time-concat.
+                # minimal/override keeps static vars (latitude(n_face), ...) from
+                # being broadcast along time or equality-compared per scan.
+                out_by[t] = xr.concat(
+                    per_scan[t], dim="time",
+                    data_vars="minimal", coords="minimal",
+                    compat="override", join="outer",
+                ).sortby("time")
+            per_scan[t] = None
+        del per_scan
+        gc.collect()
+
+    if "swath" in targets:
+        out_by["swath"] = _swath_pixels_from_paireddict(paireddict)
 
     if to_netcdf:
-        if "XYZ" in path:
-            first_time = out_regridded["time"][0].values.astype(str)[0:19]
-            last_time = out_regridded["time"][-1].values.astype(str)[0:19]
-            out_regridded.to_netcdf(path.replace("XYZ", f"{first_time}_{last_time}"))
-        else:
-            out_regridded.to_netcdf(path)
+        for t in targets:
+            _p = path if t == "model" else path.replace(".nc", f"_{t}.nc")
+            if "XYZ" in _p:
+                first_time = out_by[t]["time"][0].values.astype(str)[0:19]
+                last_time = out_by[t]["time"][-1].values.astype(str)[0:19]
+                out_by[t].to_netcdf(_p.replace("XYZ", f"{first_time}_{last_time}"))
+            else:
+                out_by[t].to_netcdf(_p)
 
-    return out_regridded
+    return out_by
+
+
+def speedup_regridding(dset, variables="all"):
+    """Makes modobj latitude and longitude C_contiguous, which speeds up regridding.
+    It makes the changes inplace
+
+    Parameters
+    ----------
+    dset : xr.Dataset
+        Dataset containing latitude and longitude
+
+    Returns
+    -------
+    None
+    """
+    if variables == "all":
+        variables = dset.variables
+    for v in variables:
+        if not dset[v].values.flags["C_CONTIGUOUS"]:
+            dtype = dset[v].dtype
+            dset[v] = dset[v].astype(dtype, order="C")
 
 
 def read_paired_gridded_tempo_model(path):

--- a/melodies_monet/util/uxarray_util.py
+++ b/melodies_monet/util/uxarray_util.py
@@ -1,0 +1,593 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+
+"""
+unstructured model output binding to a uxarray grid 
+
+these util functions only run if a grid file is provided in the YAML, preserving currently existing functionality
+
+https://uxarray.readthedocs.io/en/latest/user-guide/grid-formats.html
+
+Users should be able to provide EXODUS, UGRID, SCRIP, etc. This util file will handle all of those types automatically. 
+
+UGRID; MPAS; SCRIP; EXODUS; ESMF; GEOS CS; ICON; FESOM2; HEALPix
+
+05282026: EXODUS and SCRIP are supported; if ncol = num_element uxarray should handle automatically. If no, CKDTree is triggered for nearest neighbor interpolation. 
+
+"""
+
+import numpy as np
+try:
+    import uxarray as ux
+except ImportError:  # optional dep
+    ux = None
+import xarray as xr
+
+# Cache clean uxgrids built from SCRIP files (keyed by path). Depadding a
+# 174k-face SCRIP takes a few seconds, so build once per process.
+_CLEAN_UXGRID_CACHE = {}
+
+def to_neg180(lon):
+    """Normalize longitudes to the [-180, 180] convention.
+
+    CESM-SE (and several other models) store longitude in 0..360 while the
+    satellite L2 products report -180..180; every overlap/bbox comparison
+    must normalize first or a CONUS model and CONUS swath look disjoint.
+    """
+    return ((np.asarray(lon) + 180.0) % 360.0) - 180.0
+
+
+def read_scrip_corners(grid_file):
+    """Return ``(corner_lon, corner_lat)`` in degrees from a SCRIP file.
+
+    Shape ``(n_face, n_corners)``; radians are converted if the units
+    attribute says so. Raises ``KeyError`` for non-SCRIP files (e.g. MPAS
+    meshes), which callers treat as "cannot subset, use the full mesh".
+    """
+    with xr.open_dataset(grid_file) as s:
+        clat = np.asarray(s["grid_corner_lat"].values)
+        clon = np.asarray(s["grid_corner_lon"].values)
+        units = str(s["grid_corner_lat"].attrs.get("units", "")).lower()
+    if "rad" in units:
+        clat, clon = np.rad2deg(clat), np.rad2deg(clon)
+    return clon, clat
+
+
+def subset_mesh_to_bbox(grid_file, lon_min, lon_max, lat_min, lat_max, pad=0.5):
+    """Faces of ``grid_file`` whose centers fall inside the padded bbox.
+
+    Returns ``(keep, subgrid)``: integer indices into the full mesh's face
+    dim, and a Grid rebuilt from the kept SCRIP corners with the same
+    builder that made the full grid -- so ``keep`` indexes data and corners
+    consistently. ``subgrid`` is ``None`` when no subset is useful: the bbox
+    keeps nothing (``keep.size == 0`` -- callers usually skip) or everything
+    (callers use the full mesh).
+    """
+    full = open_uxgrid(grid_file)
+    flon, flat = _face_centers(full)
+    flon = to_neg180(flon)
+    keep = np.where(
+        (flon >= lon_min - pad) & (flon <= lon_max + pad)
+        & (flat >= lat_min - pad) & (flat <= lat_max + pad)
+    )[0]
+    if keep.size == 0 or keep.size >= int(full.n_face):
+        return keep, None
+    clon, clat = read_scrip_corners(grid_file)
+    return keep, uxgrid_from_corner_bounds(clon[keep], clat[keep])
+
+
+def subset_model_source(ds, grid_file, lon_min, lon_max, lat_min, lat_max,
+                        pad=0.5, label="subset_model_source"):
+    """Subset an unstructured model Dataset + its mesh to a bbox for regridding.
+
+    The forward (model -> swath) conservative regrid only needs the model
+    faces near the swath; building ESMF weights against the full mesh wastes
+    memory (this is the OOM fix). On success returns ``(UxDataset on the
+    subset mesh, None)`` ready for ``regrid(src, src_grid=None, ...)``; on
+    any failure or full/zero coverage returns ``(ds, grid_file)`` unchanged
+    so the caller falls back to the full mesh.
+    """
+    try:
+        keep, subgrid = subset_mesh_to_bbox(
+            grid_file, lon_min, lon_max, lat_min, lat_max, pad=pad)
+        if subgrid is None:
+            return ds, grid_file
+        n_face_full = int(open_uxgrid(grid_file).n_face)
+        col_dim = next((d for d, n in ds.sizes.items() if n == n_face_full), None)
+        if col_dim is None:
+            return ds, grid_file
+        sub = ds if hasattr(ds, "data_vars") else ds.to_dataset()
+        if col_dim != "n_face":
+            sub = sub.rename({col_dim: "n_face"})
+        print(f"{label}: mesh subset {n_face_full} -> {keep.size} faces",
+              flush=True)
+        return ux.UxDataset(sub.isel(n_face=keep), uxgrid=subgrid), None
+    except Exception as e:  # noqa: BLE001
+        print(f"{label}: mesh subset skipped ({e!r}); regridding full mesh.",
+              flush=True)
+        return ds, grid_file
+
+
+def flatten_to_faces(ds, dims, drop=()):
+    """Stack swath spatial dims to an unindexed ``n_face`` dim.
+
+    Prepares swath-shaped data as an xregrid source: geometry vars in
+    ``drop`` are removed, and any coord riding the stacked dim is dropped
+    (xregrid copies source coords to the output, where a swath-sized coord
+    collides with the model-sized output dim).
+    """
+    flat = (
+        ds.drop_vars([v for v in drop if v in ds.variables], errors="ignore")
+        .stack(n_face=dims)
+        .reset_index("n_face", drop=True)
+    )
+    return flat.drop_vars(
+        [c for c in flat.coords if "n_face" in flat[c].dims], errors="ignore")
+
+
+def faces_to_grid(out, shape, dims):
+    """Reshape each var's face-sized dim back to 2-D swath dims.
+
+    Inverse of :func:`flatten_to_faces` for the regrid output: any variable
+    with a dim of length ``shape[0]*shape[1]`` is reshaped (row-major, so
+    flatten order must match) to ``dims``; vars without one (grid/node
+    artifacts) are skipped.
+    """
+    n_face = int(np.prod(shape))
+    res = xr.Dataset(attrs=dict(out.attrs))
+    for v in out.data_vars:
+        da = out[v]
+        face_dim = next((d for d in da.dims if da.sizes[d] == n_face), None)
+        if face_dim is None:
+            continue
+        t = da.transpose(..., face_dim)
+        arr = np.asarray(t.values).reshape(t.shape[:-1] + tuple(shape))
+        res[v] = xr.DataArray(arr, dims=t.dims[:-1] + tuple(dims),
+                              attrs=dict(da.attrs))
+    return res
+
+def clean_uxgrid_from_scrip(scrip_path, fill_value=-1):
+    """Build a degeneracy-free uxarray Grid from a SCRIP file.
+
+    SCRIP stores every cell padded to ``grid_corners`` slots by *repeating*
+    corners (e.g. a quad in a 10-corner array repeats one corner 6×). Those
+    repeated corners are degenerate and make ESMF refuse to build
+    conservative weights. This depads each face to its true polygon
+    (4/6/8/10-gon for ne0CONUS dual cells) so ESMF/xregrid can do true
+    area-weighted conservative regridding.
+
+    Result is cached by ``scrip_path``.
+
+    Parameters
+    ----------
+    scrip_path : str
+        Path to a SCRIP-format grid file (``grid_corner_lat``/
+        ``grid_corner_lon`` of shape ``(n_face, n_corners)``).
+    fill_value : int
+        Sentinel for unused slots in the ragged face-node connectivity.
+
+    Returns
+    -------
+    uxarray.Grid
+        Clean grid with variable-length ``face_node_connectivity``.
+    """
+    hit = _CLEAN_UXGRID_CACHE.get(scrip_path)
+    if hit is not None:
+        return hit
+
+    clon, clat = read_scrip_corners(scrip_path)
+    grid = uxgrid_from_corner_bounds(clon, clat, fill_value=fill_value)
+    _CLEAN_UXGRID_CACHE[scrip_path] = grid
+    return grid
+
+def uxgrid_from_corner_bounds(corner_lon, corner_lat, fill_value=-1):
+    """Build a degeneracy-free uxarray Grid from per-face corner bounds.
+
+    Generalizes the SCRIP depad to any source of per-cell corner arrays —
+    including a TEMPO swath whose pixel corners come from
+    ``longitude_bounds``/``latitude_bounds``. Each face's repeated/padded
+    corners are collapsed to its true polygon (so ESMF accepts the mesh for
+    conservative regridding), and nodes shared between faces are deduped to
+    a single global node list.
+
+    NOT cached — callers with a static mesh (e.g. a model SCRIP) should
+    cache the result themselves; swath grids change per granule.
+
+    Parameters
+    ----------
+    corner_lon, corner_lat : array-like
+        Corner coordinates in **degrees**, shape ``(n_face, n_corners)``.
+        (Flatten any ``(x, y, n_corners)`` swath bounds to this first.)
+    fill_value : int
+        Sentinel for unused slots in the ragged face-node connectivity.
+
+    Returns
+    -------
+    uxarray.Grid
+        Clean grid with variable-length ``face_node_connectivity``.
+    """
+    
+    clon = np.asarray(corner_lon, dtype=float)
+    clat = np.asarray(corner_lat, dtype=float)
+    if clon.shape != clat.shape or clon.ndim != 2:
+        raise ValueError(
+            "uxgrid_from_corner_bounds: corner_lon/corner_lat must both be "
+            f"2-D (n_face, n_corners). Got {clon.shape}, {clat.shape}."
+        )
+    nf, mc = clon.shape
+
+    # Global node dedup via a rounded (lon, lat) key.
+    key = np.round(np.stack([clon.ravel(), clat.ravel()], axis=1), 4)
+    uniq, inv = np.unique(key, axis=0, return_inverse=True)
+    node_lon = uniq[:, 0].astype(float)
+    node_lat = uniq[:, 1].astype(float)
+    inv = inv.reshape(nf, mc)
+
+    # Per-face consecutive dedup (corners are padded by repetition); drop a
+    # closing duplicate if last kept == first.
+    face_conn = np.full((nf, mc), fill_value, dtype=np.int64)
+    for i in range(nf):
+        row = inv[i]
+        keep = [int(row[0])]
+        for j in range(1, mc):
+            if int(row[j]) != keep[-1]:
+                keep.append(int(row[j]))
+        if len(keep) > 1 and keep[-1] == keep[0]:
+            keep.pop()
+        face_conn[i, : len(keep)] = keep
+
+    return ux.Grid.from_topology(
+        node_lon=node_lon,
+        node_lat=node_lat,
+        face_node_connectivity=face_conn,
+        fill_value=fill_value,
+    )
+
+def open_uxgrid(grid_file, fill_value=-1):
+    """Open any unstructured grid file as a clean uxarray Grid (cached).
+
+    Dispatches by format so callers don't care whether the model ships a
+    padded SCRIP (ne0CONUS / CESM-SE) or a native mesh (MPAS):
+
+    - **SCRIP** (has ``grid_corner_lat``/``grid_corner_lon``): the corners are
+      padded to a fixed width by *repeating* nodes, which ESMF rejects for
+      conservative regridding. Depad them via :func:`clean_uxgrid_from_scrip`.
+    - **MPAS / UGRID / EXODUS**: uxarray reads these natively
+      (``ux.open_grid``) -- clean Voronoi/polygon cells, no padding, lon/lat
+      unit handling (e.g. MPAS radians) done internally. No depad needed.
+
+    Parameters
+    ----------
+    grid_file : str
+        Path to a SCRIP, MPAS, UGRID, or EXODUS grid/mesh file.
+    fill_value : int
+        Fill sentinel for the SCRIP depad path.
+
+    Returns
+    -------
+    uxarray.Grid
+    """
+    hit = _CLEAN_UXGRID_CACHE.get(grid_file)
+    if hit is not None:
+        return hit
+
+    with xr.open_dataset(grid_file) as ds:
+        is_scrip = (
+            "grid_corner_lat" in ds.variables
+            and "grid_corner_lon" in ds.variables
+        )
+
+    if is_scrip:
+        # clean_uxgrid_from_scrip caches under the same key as well.
+        grid = clean_uxgrid_from_scrip(grid_file, fill_value=fill_value)
+    else:
+        # MPAS / UGRID / EXODUS -> uxarray auto-detects and gives clean cells.
+        grid = ux.open_grid(grid_file)
+
+    _CLEAN_UXGRID_CACHE[grid_file] = grid
+    return grid
+
+def _coord(obj, names):
+    """Return ``(name, coord)`` for the first of ``names`` present on ``obj``.
+
+    Works for both ``xarray.Dataset`` and ``xarray.DataArray``; longitude /
+    latitude may live in coords or (for a Dataset) data_vars.
+    """
+    for name in names:
+        if name in obj.coords:
+            return name, obj.coords[name]
+        if name in getattr(obj, "data_vars", {}):
+            return name, obj[name]
+    return None, None
+
+def _spatial_dim(obj):
+    """Return ``(dim_name, lon_coord_name)`` for the unstructured column dim.
+
+    Located via the longitude coordinate, which is 1-D along the column
+    dimension for unstructured (e.g. CESM-SE ``ncol``) output.
+    """
+    name, lon = _coord(obj, ("longitude", "lon", "Longitude"))
+    if lon is None or lon.ndim != 1:
+        raise ValueError(
+            "Could not locate a 1-D 'longitude' coordinate to identify the "
+            "unstructured spatial dimension."
+        )
+    return lon.dims[0], name
+
+
+def _lat_name(obj):
+    name, lat = _coord(obj, ("latitude", "lat", "Latitude"))
+    if lat is None:
+        raise ValueError("Could not locate a 'latitude' coordinate.")
+    return name
+
+
+def _face_centers(uxgrid):
+    """Return (lon, lat) face centers.
+
+    Uses uxarray's built-in, vectorized face-center coordinates rather than a
+    Python loop over faces (much faster on large grids). Falls back to a
+    connectivity-based mean only if those properties are unavailable.
+    """
+    try:
+        return np.asarray(uxgrid.face_lon.values), np.asarray(uxgrid.face_lat.values)
+    except (AttributeError, ValueError):
+        face_node = uxgrid.face_node_connectivity.values
+        node_lon = uxgrid.node_lon.values
+        node_lat = uxgrid.node_lat.values
+        masked = np.where(face_node >= 0, face_node, 0)
+        valid = (face_node >= 0).astype(float)
+        counts = valid.sum(axis=1)
+        center_lon = (node_lon[masked] * valid).sum(axis=1) / counts
+        center_lat = (node_lat[masked] * valid).sum(axis=1) / counts
+        return center_lon, center_lat
+
+
+def _face_for_columns(uxgrid, mlon, mlat):
+    """Nearest grid face for each model column (mirrors the Plot_2D cKDTree)."""
+    from scipy.spatial import cKDTree
+
+    center_lon, center_lat = _face_centers(uxgrid)
+    mlon = np.asarray(mlon)
+    mlon = np.where(mlon > 180, mlon - 360, mlon)
+    flon = np.where(center_lon > 180, center_lon - 360, center_lon)
+
+    tree = cKDTree(np.column_stack([flon, center_lat]))
+    _, face_for_col = tree.query(np.column_stack([mlon, np.asarray(mlat)]))
+    return face_for_col
+
+
+def _bin_to_faces(obj, uxgrid, spatial_dim, face_for_col):
+    """Average values on ``spatial_dim`` into faces, preserving other dims.
+
+    Faces with no column map to NaN, matching the prior Plot_2D behavior.
+    Accepts a Dataset or DataArray and returns the same type with the column
+    dimension replaced by ``n_face``.
+    """
+    n_face = uxgrid.n_face
+    return (
+        obj.assign_coords(_face=(spatial_dim, face_for_col))
+        .groupby("_face")
+        .mean(skipna=True)
+        .reindex(_face=np.arange(n_face))
+        .rename({"_face": "n_face"})
+    )
+
+
+def model_to_uxdataset(obj, grid_file):
+    """Bind a model Dataset to a uxarray Grid, aligned to the grid's faces.
+
+    Parameters
+    ----------
+    obj : xarray.Dataset
+        Model output on an unstructured column dimension (e.g. CESM-SE
+        ``ncol``) with 1-D ``longitude``/``latitude`` coordinates.
+    grid_file : str
+        Path to a uxarray-readable grid file (e.g. EXODUS).
+
+    Returns
+    -------
+    uxarray.UxDataset
+        Dataset whose spatial dimension is the grid's ``n_face`` and whose
+        ordering matches the grid faces. ``obj`` is not modified.
+    """
+    uxgrid = ux.open_grid(grid_file)
+    spatial_dim, lon_name = _spatial_dim(obj)
+    lat_name = _lat_name(obj)
+
+    if obj.sizes[spatial_dim] == uxgrid.n_face:
+        aligned = obj.rename({spatial_dim: "n_face"})
+    else:
+        face_for_col = _face_for_columns(
+            uxgrid, obj[lon_name].values, obj[lat_name].values
+        )
+        spatial_vars = [v for v in obj.data_vars if spatial_dim in obj[v].dims]
+        aligned = _bin_to_faces(obj[spatial_vars], uxgrid, spatial_dim, face_for_col)
+
+    return ux.UxDataset(aligned, uxgrid=uxgrid)
+
+
+def uxda_from_columns(da, uxgrid):
+    """Build a face-aligned :class:`uxarray.UxDataArray` from a 1-D column field.
+
+    ``da`` is a model field on the unstructured column dimension with 1-D
+    ``longitude``/``latitude`` coordinates (e.g. a time-mean CESM-SE slice,
+    possibly already region-cropped). Returns a UxDataArray over the grid's
+    ``n_face`` dimension, ready for uxarray plotting. ``da`` is not modified.
+    """
+    spatial_dim, lon_name = _spatial_dim(da)
+    lat_name = _lat_name(da)
+    name = da.name if da.name is not None else "_v"
+    n_face = uxgrid.n_face
+
+    if da.sizes[spatial_dim] == n_face:
+        aligned = da.rename({spatial_dim: "n_face"})
+        return ux.UxDataArray(aligned, uxgrid=uxgrid)
+
+    face_for_col = _face_for_columns(
+        uxgrid, da[lon_name].values, da[lat_name].values)
+
+    if da.ndim == 1:
+        values = np.asarray(da.values, dtype=float)
+        fc = np.asarray(face_for_col)
+        valid = ~np.isnan(values)
+        face_sum = np.bincount(fc[valid], weights=values[valid], minlength=n_face)
+        face_cnt = np.bincount(fc[valid], minlength=n_face)
+        binned = np.where(face_cnt > 0, face_sum / np.maximum(face_cnt, 1), np.nan)
+        aligned = xr.DataArray(binned, dims=["n_face"], name=name)
+        
+    else:
+        aligned = _bin_to_faces(
+            da.to_dataset(name=name), uxgrid, spatial_dim, face_for_col
+        )[name]
+
+    return ux.UxDataArray(aligned, uxgrid=uxgrid)
+
+
+def sample_unstructured_at_points(
+    modobj, target_lon, target_lat, max_distance=None, radius=None,):
+    """Sample a model on a 1-D unstructured column dim at arbitrary
+    ``(lon, lat)`` target points.
+
+    Two aggregation modes:
+
+    - **Nearest neighbor** (default, ``radius=None``): each target gets the
+      single nearest source value. Optionally capped by ``max_distance``.
+    - **Within-radius mean** (``radius=<float deg>``): each target gets the
+      *mean* of all sources within ``radius`` of it. Poor-man's area-weighted
+      aggregation -- use in the swath -> unstructured-model direction when
+      you'd rather average all swath pixels that fall near a model cell than
+      snap to the single nearest. Targets with no source in range -> NaN.
+
+    Reusable beyond the satellite pipeline: any caller with a list of target
+    points (swath pixels, AirNow stations, sondes, ...) can sample an unstructured model at those locations without xESMF.
+
+    Parameters
+    ----------
+    modobj : xarray.Dataset
+    Model on a 1-D unstructured column dim with 1-D ``longitude``/
+    ``latitude`` coordinates.
+    target_lon, target_lat : 1-D array-like
+    Target points. Convention-agnostic; both sides normalized to
+        ``-180..180`` before the KDTree query.
+    max_distance : float, optional
+        Only used when ``radius`` is None. Distance cap for nearest-neighbor;
+        targets with no source within this distance NaN out.
+    radius : float, optional
+        If set, switches to within-radius averaging mode. Distance in
+        degrees, Euclidean in lon/lat space.
+
+    Returns
+    -------
+    xarray.Dataset
+        Same data_vars as ``modobj`` but with the column dim replaced by a
+        1-D ``target`` dim of length ``len(target_lon)``. Other dims
+        (time, z, ...) and attrs are preserved.
+    """
+
+    from scipy.spatial import cKDTree
+
+    modobj = modobj.load()
+    
+    mlon = np.asarray(modobj["longitude"].values)
+    mlat = np.asarray(modobj["latitude"].values)
+    mlon = ((mlon + 180.0) % 360.0) - 180.0
+
+    tlon = np.asarray(target_lon, dtype=float)
+    tlat = np.asarray(target_lat, dtype=float)
+    tlon = ((tlon + 180.0) % 360.0) - 180.0
+
+    # cKDTree.query rejects NaN/Inf inputs. Real swath data has them on edge
+    # pixels / fill values; query only finite targets and mask the rest below.
+    # valid = np.isfinite(tlon) & np.isfinite(tlat)
+
+    svalid = np.isfinite(mlon) & np.isfinite(mlat)
+    if not svalid.any():
+        raise ValueError(
+            "sample_unstructured_at_points: no finite source points to build "
+            "the KDTree from."
+        )
+    src_orig_idx = np.where(svalid)[0]
+    tree = cKDTree(np.column_stack([mlon[svalid], mlat[svalid]]))
+
+    tvalid = np.isfinite(tlon) & np.isfinite(tlat)
+
+    col_dim = modobj["longitude"].dims[0]
+    n_target = tlon.shape[0]
+
+    # === Within-radius averaging path (poor-man's area-weighted) ===
+    if radius is not None:
+        # Restrict the (expensive) ball query to targets inside the source
+        smin_lon, smax_lon = np.nanmin(mlon[svalid]), np.nanmax(mlon[svalid])
+        smin_lat, smax_lat = np.nanmin(mlat[svalid]), np.nanmax(mlat[svalid])
+        inbox = (
+            (tlon >= smin_lon - radius) & (tlon <= smax_lon + radius)
+            & (tlat >= smin_lat - radius) & (tlat <= smax_lat + radius)
+        )
+        tquery = tvalid & inbox
+        
+        neighbor_lists = tree.query_ball_point(
+            np.column_stack([tlon[tquery], tlat[tquery]]), r=radius
+        )
+        tvalid_pos = np.where(tquery)[0]
+        out = xr.Dataset(attrs=dict(modobj.attrs))
+        for v in modobj.data_vars:
+            da = modobj[v]
+            if col_dim not in da.dims:
+                out[v] = da
+                continue
+            transposed = da.transpose(..., col_dim)
+            arr = np.asarray(transposed.values)
+            new_dims = transposed.dims[:-1] + ("target",)
+            out_arr = np.full(arr.shape[:-1] + (n_target,), np.nan, dtype=float)
+            for ti, neigh in zip(tvalid_pos, neighbor_lists):
+                if len(neigh) == 0:
+                    continue
+                sources = src_orig_idx[np.asarray(neigh, dtype=np.intp)]
+                with np.errstate(invalid="ignore"):
+                    out_arr[..., ti] = np.nanmean(arr[..., sources], axis=-1)
+            out[v] = xr.DataArray(out_arr, dims=new_dims, attrs=dict(da.attrs))
+        out = out.assign_coords(
+            longitude=("target", np.asarray(tlon)),
+            latitude=("target", np.asarray(tlat)),
+        )
+        return out
+
+    # === Nearest-neighbor path ===
+    idx = np.zeros(tlon.shape[0], dtype=np.intp)
+    # Track which targets actually got a real nearest source within reach.
+    # Targets without one stay False and get masked to NaN below.
+    paired = np.zeros(tlon.shape[0], dtype=bool)
+    
+    if tvalid.any():
+        query_kwargs = {}
+        if max_distance is not None:
+            query_kwargs["distance_upper_bound"] = max_distance
+        dist, idx_in_valid = tree.query(
+            np.column_stack([tlon[tvalid], tlat[tvalid]]), **query_kwargs
+        )
+        # cKDTree returns idx == n (i.e. len(src_orig_idx)) for "no neighbor
+        # within distance_upper_bound". Treat those as unpaired.
+        n_src = len(src_orig_idx)
+        within = idx_in_valid < n_src
+        # Avoid out-of-range indexing for unpaired entries
+        safe_idx = np.where(within, idx_in_valid, 0)
+        idx[tvalid] = src_orig_idx[safe_idx]
+        tvalid_pos = np.where(tvalid)[0]
+        paired[tvalid_pos[within]] = True
+    
+    sampled = modobj.isel({col_dim: idx}).rename({col_dim: "target"})
+    # Mask: target keeps its sampled value only if it was both (a) finite and
+    # (b) within the distance cap of an actual source point. Everything else
+    # NaNs out -- this is what stops the "nearest-neighbor smear" of distant
+    # swath pixels across the whole CONUS grid when only a single swath is
+    # available.
+    keep = tvalid & paired
+    if not keep.all():
+        sampled = sampled.where(xr.DataArray(keep, dims=["target"]))
+
+    return sampled
+
+
+    
+


### PR DESCRIPTION
# TEMPO L2 conservative pairing rework

Reworks TEMPO NO₂/HCHO pairing to support true conservative regridding in both directions, alongside the existing nearest-neighbour path.

## What's changed

- `_conservative_mod2swath` / `_conservative_swath2mod_scan` — area-weighted model↔swath regridding, with swath geometry built from L2 pixel corner bounds and weights rebuilt per granule.

- `_apply_scattering_weights` (+ hydrostatic variant) — applies retrieval scattering weights / AMF so the model column is directly comparable to the retrieval. The four `apply_weights_mod2tempo_*` entry points are preserved as thin wrappers over this shared core.

- `_unstructured_back_to_modgrid` — returns paired swath data to an unstructured model mesh.

- Adds native-swath targets, `save_vars`, and `crop_extent` for bounded-memory runs.

- `calc_partialcolumn` is now imported from `util.tools` rather than duplicated here; the module-level import keeps `sat_l2_swath_utility_tempo.calc_partialcolumn` resolving for any external caller.

## Compatibility

No existing public function is removed — all functions on `develop` remain available.

## Dependencies

> **Depends on #454 and #455** — please merge those first.