### PR TITLE
Casper equivalent .sh file

### DIFF
--- a/examples/submit_jobs/submit_casper.sh
+++ b/examples/submit_jobs/submit_casper.sh
@@ -1,0 +1,54 @@
+#!/bin/bash -l
+
+#PBS -N mm_eval
+#PBS -q casper
+#PBS -l select=1:ncpus=1:mem=64GB
+#PBS -l walltime=05:00:00
+#PBS -j oe
+# -- Update to your project code
+#PBS -A PXXXXXXXX
+
+# PBS example for NCAR Casper. See submit_hera.sh for the Slurm equivalent.
+
+# -- Update to your conda environment
+module load conda
+conda activate melodies-monet
+
+# -- Update to the location of your run script
+cd /glade/work/$USER/MELODIES-MONET/examples/submit_jobs/
+
+python run_melodies_monet.py
+
+# ---------------------------------------------------------------------------
+# Running one day per job with a PBS job array
+# ---------------------------------------------------------------------------
+# Satellite pairing is often too large for a single job. A job array runs one
+# day per element, with a concurrency cap so a month does not swamp the queue:
+#
+#   #PBS -J 1-30%6            # 30 elements, at most 6 running at once
+#
+# and derive the date from the array index:
+#
+#   export YMD=$(printf "202406%02d" ${PBS_ARRAY_INDEX})   # 20240601..20240630
+#
+# Your run script then reads YMD (via os.environ) to select that day's input
+# files and name its output.
+#
+# Two things to watch:
+#
+#   * A degenerate range is rejected. `-J 5-5` is an error, not a one-element
+#     array. To rerun a single day, submit it directly and pass the date in:
+#         qsub -v YMD=20240605 submit_casper.sh
+#
+#   * `-v` lists must not contain spaces. `-v RUN=ref, YMD=20240605` silently
+#     drops YMD -- the job runs with it unset. Write `-v RUN=ref,YMD=20240605`.
+#
+# Fanning out over several model runs, one job each:
+#
+#   for RUN in ref alt; do
+#     qsub -N mm_${RUN} -o mm_${RUN}.log -v RUN=$RUN submit_casper.sh
+#   done
+#
+# Memory scales with the target grid rather than the observation volume, so
+# unstructured meshes need considerably more than a lat/lon grid of the same
+# nominal resolution. Check a single day before committing a month.


### PR DESCRIPTION
# Add a PBS submission example for NCAR Casper

Adds a PBS submission example for NCAR's Casper HPC environment.

## New example

`examples/submit_jobs/submit_casper.sh`

This is the PBS analogue of the existing Slurm submission scripts:

* follows the same `# -- Update to your ...` configuration style
* calls the existing `run_melodies_monet.py` workflow
* provides a starting point for Casper users without requiring them to translate Slurm directives

No existing files are modified.

---

## PBS job arrays for satellite pairing

Large satellite pairing workflows are typically run as one PBS array element per day.

Example:

```bash
qsub -J 1-30%6 submit_casper.sh
```

This submits a June-style monthly run with:

* 30 array elements (one per day)
* a maximum of 6 simultaneous jobs

The script should derive the date from the PBS array index and pass it into the MELODIES-MONET control workflow.

---

## PBS behaviours to note

### Single-day reruns

PBS rejects a degenerate array range:

```bash
-J 5-5
```

is **not** interpreted as a one-element array. It returns an error.

To rerun a single day, submit it directly:

```bash
qsub -v YMD=20240605 submit_casper.sh
```

---

### Environment variable spacing

PBS `-v` syntax does not tolerate spaces.

This silently drops variables:

```bash
-v RUN=ref, YMD=20240605
```

The job receives:

```text
RUN=ref
```

but `YMD` is missing.

Use:

```bash
-v RUN=ref,YMD=20240605
```

with no spaces.

---

## Summary

This PR adds:

* a Casper PBS submission template
* documentation for PBS array usage
* common PBS pitfalls for NCAR users

The change is documentation/example-only and does not affect existing workflows.
